### PR TITLE
Additional service close method

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ There are two predefined by container service types that may be used as a depend
 A service is a functional component of the application, created and managed by a Service Factory. 
 The lifetime of a service is tied to the lifetime of the entire container.
 
-A service may optionally implement a `Close() error` method, which is called when the container is shutting down.
+A service may optionally implement a `Close() error` or just `Close()` method, which is called when the container is shutting down.
 
 ```go
 // MyService defines example service.

--- a/registry.go
+++ b/registry.go
@@ -108,12 +108,17 @@ func (r *registry) closeFactories() error {
 				// Get the factory result object interface.
 				service := factoryOutValue.Interface()
 
-				// Close service implementing closer interface.
+				// Close service implementing `Close() error` interface.
 				// Service functions will wait for the function return.
 				if closer, ok := service.(interface{ Close() error }); ok {
 					if err := closer.Close(); err != nil {
 						errs = append(errs, err.Error())
 					}
+				}
+
+				// Close service implementing `Close()` interface.
+				if closer, ok := service.(interface{ Close() }); ok {
+					closer.Close()
 				}
 			}
 		}


### PR DESCRIPTION
Sometimes it is useful to close also a services which are implementing not the `Close() error` interface but just `Close()` one. It is really inconvenient to make wrappers just for changing close method signature.