### PR TITLE
Detailed start and close error messages

### DIFF
--- a/factory_test.go
+++ b/factory_test.go
@@ -62,7 +62,7 @@ func TestFactoryInfo(t *testing.T) {
 			name:  "FactoryLocalFunc",
 			arg1:  NewFactory(localFunc),
 			want1: "Factory[func(gontainer.globalType) string]",
-			want2: "github.com/NVIDIA/gontainer.TestFactoryInfo",
+			want2: "github.com/NVIDIA/gontainer",
 		},
 		{
 			name:  "FactoryGlobalFunc",


### PR DESCRIPTION
Detailed error messages on:

* on fail of container start (on first failed instantiation);
* on fail of container close (aggregated of all close errors).