### PR TITLE
Implement invoker service

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ type Container interface {
 	// will be spawned on `resolver.Resolve(...)` call.
 	Resolver() Resolver
 
-	// Resolver returns function invoker instance.
+	// Invoker returns function invoker instance.
 	// If container is not started, only requested services
 	// will be spawned to invoke the func.
 	Invoker() Invoker

--- a/README.md
+++ b/README.md
@@ -155,9 +155,9 @@ type Container interface {
 	// will be spawned on `resolver.Resolve(...)` call.
 	Resolver() Resolver
 
-    // Resolver returns function invoker instance.
-    // If container is not started, only requested services
-    // will be spawned to invoke the func.
+	// Resolver returns function invoker instance.
+	// If container is not started, only requested services
+	// will be spawned to invoke the func.
 	Invoker() Invoker
 }
 ```

--- a/README.md
+++ b/README.md
@@ -61,6 +61,23 @@ Dependency injection service container for Golang projects.
       log.Fatalf("Failed to start service container: %s", err)
    }
    ```
+   
+6. Alternatively to eager start with a `Start()` call it is possible to use `Resolver` or `Invoker` service. It will spawn only explicitly requested services. 
+   ```go
+   var MyService myService
+   if err := container.Resolver().Resolve(&MyService); err != nil {
+       log.Fatalf("Failed to resolve MyService dependency: %s", err)
+   }
+   myServise.DoSomething()
+   ```
+   or
+   ```go
+   if err := container.Invoker().Invoke(func(myService &MyService) {
+       myServise.DoSomething()
+   }); err != nil {
+       log.Fatalf("Failed to invoke a function: %s", err)
+   }
+   ```
 
 ## Key Concepts
 
@@ -107,6 +124,7 @@ There are several predefined by container service types that may be used as a de
 1. The `gontainer.Events` service provides the events broker. It can be used to send and receive events
    inside service container between services or outside from the client code.
 1. The `gontainer.Resolver` service provides a service to resolve dependencies dynamically.
+1. The `gontainer.Invoker` service provides a service to invoke functions dynamically.
 
 ### Container Interface
 
@@ -133,14 +151,12 @@ type Container interface {
 	Events() Events
 
 	// Resolver returns service resolver instance.
-	// If container is not started, only requested services
+	// If container is not started only requested services
 	// will be spawned on `resolver.Resolve(...)` call.
 	Resolver() Resolver
 
-	// Invoke invokes specified function.
-	// If container is not started, only requested services
-	// will be spawned to invoke the func.
-	Invoke(fn any) ([]any, error)
+    // Resolver returns function invoker instance.
+	Invoker() Invoker
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -151,11 +151,13 @@ type Container interface {
 	Events() Events
 
 	// Resolver returns service resolver instance.
-	// If container is not started only requested services
+	// If container is not started, only requested services
 	// will be spawned on `resolver.Resolve(...)` call.
 	Resolver() Resolver
 
     // Resolver returns function invoker instance.
+    // If container is not started, only requested services
+    // will be spawned to invoke the func.
 	Invoker() Invoker
 }
 ```

--- a/container_test.go
+++ b/container_test.go
@@ -34,7 +34,7 @@ func TestContainerLifecycle(t *testing.T) {
 	equal(t, container == nil, false)
 
 	// Assert factories and services.
-	equal(t, len(container.Factories()), 6)
+	equal(t, len(container.Factories()), 7)
 	equal(t, len(container.Services()), 0)
 
 	// Start all factories in the container.
@@ -43,8 +43,8 @@ func TestContainerLifecycle(t *testing.T) {
 	equal(t, serviceClosed.Load(), false)
 
 	// Assert factories and services.
-	equal(t, len(container.Factories()), 6)
-	equal(t, len(container.Services()), 7)
+	equal(t, len(container.Factories()), 7)
+	equal(t, len(container.Services()), 8)
 
 	// Let factory function start executing in the background.
 	time.Sleep(time.Millisecond)
@@ -60,6 +60,6 @@ func TestContainerLifecycle(t *testing.T) {
 	<-container.Done()
 
 	// Assert factories and services.
-	equal(t, len(container.Factories()), 6)
+	equal(t, len(container.Factories()), 7)
 	equal(t, len(container.Services()), 0)
 }

--- a/factory.go
+++ b/factory.go
@@ -123,13 +123,18 @@ func (f *Factory) load(ctx context.Context) error {
 	f.factoryOutTypes = make([]reflect.Type, 0, f.factoryType.NumOut())
 	f.factoryOutValues = make([]reflect.Value, 0, f.factoryType.NumOut())
 	for index := 0; index < f.factoryType.NumOut(); index++ {
-		if index != f.factoryType.NumOut()-1 || f.factoryType.Out(index) != errorType {
-			// Register regular factory output type.
-			f.factoryOutTypes = append(f.factoryOutTypes, f.factoryType.Out(index))
-		} else {
-			// Register last output index as an error.
-			f.factoryOutError = true
+		// If it is the last return value.
+		if index == f.factoryType.NumOut()-1 {
+			// And type of the value is the error.
+			if f.factoryType.Out(index) == errorType {
+				// Register last output index as an error.
+				f.factoryOutError = true
+				break
+			}
 		}
+
+		// Register regular factory output type.
+		f.factoryOutTypes = append(f.factoryOutTypes, f.factoryType.Out(index))
 	}
 
 	// Save the factory load status.

--- a/factory.go
+++ b/factory.go
@@ -123,18 +123,13 @@ func (f *Factory) load(ctx context.Context) error {
 	f.factoryOutTypes = make([]reflect.Type, 0, f.factoryType.NumOut())
 	f.factoryOutValues = make([]reflect.Value, 0, f.factoryType.NumOut())
 	for index := 0; index < f.factoryType.NumOut(); index++ {
-		// If it is the last return value.
-		if index == f.factoryType.NumOut()-1 {
-			// And type of the value is the error.
-			if f.factoryType.Out(index) == errorType {
-				// Register last output index as an error.
-				f.factoryOutError = true
-				break
-			}
+		if index != f.factoryType.NumOut()-1 || f.factoryType.Out(index) != errorType {
+			// Register regular factory output type.
+			f.factoryOutTypes = append(f.factoryOutTypes, f.factoryType.Out(index))
+		} else {
+			// Register last output index as an error.
+			f.factoryOutError = true
 		}
-
-		// Register regular factory output type.
-		f.factoryOutTypes = append(f.factoryOutTypes, f.factoryType.Out(index))
 	}
 
 	// Save the factory load status.

--- a/invoker.go
+++ b/invoker.go
@@ -47,6 +47,7 @@ func (i *invoker) Invoke(fn any) (InvokeResult, error) {
 			if fnOut.Type().Implements(errorType) {
 				// Use the value as an error.
 				result.err = fnOut.Interface().(error)
+				break
 			}
 		}
 

--- a/invoker.go
+++ b/invoker.go
@@ -1,0 +1,83 @@
+package gontainer
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// Invoker defines invoker interface.
+type Invoker interface {
+	// Invoke invokes specified function.
+	Invoke(fn any) (InvokeResult, error)
+}
+
+// invoker implements invoker interface.
+type invoker struct {
+	resolver Resolver
+}
+
+// Invoke invokes specified function.
+func (i *invoker) Invoke(fn any) (InvokeResult, error) {
+	// Get reflection of the fn.
+	fnValue := reflect.ValueOf(fn)
+	if fnValue.Kind() != reflect.Func {
+		return nil, fmt.Errorf("fn must be a function")
+	}
+
+	// Resolve function arguments.
+	fnInArgs := make([]reflect.Value, 0, fnValue.Type().NumIn())
+	for index := 0; index < fnValue.Type().NumIn(); index++ {
+		fnArgPtrValue := reflect.New(fnValue.Type().In(index))
+		if err := i.resolver.Resolve(fnArgPtrValue.Interface()); err != nil {
+			return nil, fmt.Errorf("failed to resolve dependency: %w", err)
+		}
+		fnInArgs = append(fnInArgs, fnArgPtrValue.Elem())
+	}
+
+	// Convert function results.
+	fnOutArgs := fnValue.Call(fnInArgs)
+	result := &invokeResult{
+		values: make([]any, 0, len(fnOutArgs)),
+		err:    nil,
+	}
+	for index, fnOut := range fnOutArgs {
+		// If it is the last return value.
+		if index == len(fnOutArgs)-1 {
+			// And type of the value is the error.
+			if fnOut.Type().Implements(errorType) {
+				// Use the value as an error.
+				result.err = fnOut.Interface().(error)
+			}
+		}
+
+		// Add value to the results slice.
+		result.values = append(result.values, fnOut.Interface())
+	}
+
+	return result, nil
+}
+
+// InvokeResult provides access to the invocation result.
+type InvokeResult interface {
+	// Values returns a slice of function result values.
+	Values() []any
+
+	// Error returns function result error, if any.
+	Error() error
+}
+
+// invokeResult implements corresponding interface.
+type invokeResult struct {
+	values []any
+	err    error
+}
+
+// Values implements corresponding interface method.
+func (r *invokeResult) Values() []any {
+	return r.values
+}
+
+// Error implements corresponding interface method.
+func (r *invokeResult) Error() error {
+	return r.err
+}

--- a/invoker.go
+++ b/invoker.go
@@ -47,7 +47,6 @@ func (i *invoker) Invoke(fn any) (InvokeResult, error) {
 			if fnOut.Type().Implements(errorType) {
 				// Use the value as an error.
 				result.err = fnOut.Interface().(error)
-				break
 			}
 		}
 

--- a/invoker_test.go
+++ b/invoker_test.go
@@ -1,0 +1,92 @@
+package gontainer
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestInvokerService tests invoker service.
+func TestInvokerService(t *testing.T) {
+	tests := []struct {
+		name    string
+		haveFn  any
+		wantFn  func(t *testing.T, value InvokeResult)
+		wantErr bool
+	}{
+		{
+			name:   "ReturnNothing",
+			haveFn: func(var1 string, var2 int) {},
+			wantFn: func(t *testing.T, value InvokeResult) {
+				equal(t, len(value.Values()), 0)
+				equal(t, value.Error(), nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "ReturnValuesNoError",
+			haveFn: func(var1 string, var2 int) (string, int, bool) {
+				return var1 + "-X", var2 + 100, true
+			},
+			wantFn: func(t *testing.T, value InvokeResult) {
+				equal(t, len(value.Values()), 3)
+				equal(t, value.Values()[0], "string-X")
+				equal(t, value.Values()[1], 223)
+				equal(t, value.Values()[2], true)
+				equal(t, value.Error(), nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "ReturnNoValuesWithError",
+			haveFn: func(var1 string, var2 int) (string, int, error) {
+				return var1 + "-X", var2 + 100, errors.New("failed")
+			},
+			wantFn: func(t *testing.T, value InvokeResult) {
+				equal(t, len(value.Values()), 3)
+				equal(t, value.Values()[0], "string-X")
+				equal(t, value.Values()[1], 223)
+				equal(t, value.Values()[2].(error).Error(), "failed")
+				equal(t, value.Error().Error(), "failed")
+				equal(t, value.Error(), value.Values()[2])
+			},
+			wantErr: false,
+		},
+		{
+			name: "ReturnMultipleError",
+			haveFn: func(var1 string, var2 int) (error, error, error) {
+				return nil, errors.New("error-1"), errors.New("error-2")
+			},
+			wantFn: func(t *testing.T, value InvokeResult) {
+				equal(t, len(value.Values()), 3)
+				equal(t, value.Values()[0], nil)
+				equal(t, value.Values()[1].(error).Error(), "error-1")
+				equal(t, value.Values()[2].(error).Error(), "error-2")
+				equal(t, value.Error().Error(), "error-2")
+				equal(t, value.Error(), value.Values()[2])
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			container, err := New(
+				NewFactory(func() string { return "string" }),
+				NewFactory(func() int { return 123 }),
+			)
+			equal(t, err, nil)
+			equal(t, container == nil, false)
+			defer func() {
+				equal(t, container.Close(), nil)
+			}()
+
+			result, err := container.Invoker().Invoke(tt.haveFn)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Invoke() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantFn != nil {
+				tt.wantFn(t, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Separate invoker with an error access API.

1. Invoker now is a standalone service.
2. `Invoke()` method returns `InvokeResult` interface.
3. `InvokeResults` provides `Error() error` method giving access to optional error result.