### PR TITLE
Typed signatures for event handlers

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       - name: Build
         run: go build -v ./...
       - name: Test

--- a/README.md
+++ b/README.md
@@ -186,6 +186,35 @@ to publish events to, and subscribe to events from, a centralized broker.
 This mechanism allows services to remain decoupled while still being able to interact through a centralized medium.
 In particular, the `gontainer.Events` service provides an interface to the events broker and can be injected as a dependency in any service factory.
 
+#### Triggering Events
+
+To trigger an event, use the `Trigger()` method. Create an event using `NewEvent()` and pass the necessary arguments:
+
+```go
+events.Trigger(gontainer.NewEvent("Event1", event, arguments, here))
+```
+
+#### Subscribing to Events
+
+To subscribe to an event, use the `Subscribe()` method. Two types of handler functions are supported:
+
+- A function that accepts a variable number of any-typed arguments:
+  ```go
+  events.Subscribe("Event1", func(args ...any) {
+      // Handle the event with args slice.
+  })
+  ```
+- A function that accepts concrete argument types:
+  ```go
+  ev.Subscribe("Event1", func(x string, y int, z bool) {
+      // Handle the event with specific args.
+  })
+  ```
+  - The **number of arguments** in the event and the handler can differ because handlers are designed to be flexible and can process varying numbers and types of arguments, allowing for greater versatility in handling different event scenarios.
+  - The **types of arguments** in the event and the handler must be assignable. Otherwise, an error will be returned from a `Trigger()` call.
+  
+Every handler function could return an `error` which will be joined and returned from `Trigger()` call.
+
 ### Container Interface
 
 ```go

--- a/container.go
+++ b/container.go
@@ -24,6 +24,24 @@ import (
 	"sync"
 )
 
+// Events declaration.
+const (
+	// ContainerStarting declares container starting event.
+	ContainerStarting = "ContainerStarting"
+
+	// ContainerStarted declares container started event.
+	ContainerStarted = "ContainerStarted"
+
+	// ContainerClosing declares container closing event.
+	ContainerClosing = "ContainerClosing"
+
+	// ContainerClosed declares container closed event.
+	ContainerClosed = "ContainerClosed"
+
+	// UnhandledPanic declares unhandled panic in container.
+	UnhandledPanic = "UnhandledPanic"
+)
+
 // New returns new container instance with a set of configured services.
 // The `factories` specifies factories for services with dependency resolution.
 func New(factories ...*Factory) (result Container, err error) {
@@ -43,7 +61,10 @@ func New(factories ...*Factory) (result Container, err error) {
 	}()
 
 	// Prepare events broker instance.
-	events := events{}
+	events := &events{
+		mutex:  sync.RWMutex{},
+		events: make(map[string][]handler),
+	}
 
 	// Prepare services registry instance.
 	registry := &registry{events: events}

--- a/events.go
+++ b/events.go
@@ -61,10 +61,12 @@ func (em *events) Subscribe(name string, handlerFn any) {
 
 	// Register event handler function.
 	if handlerType.NumIn() == 1 && handlerType.In(0) == anySliceType {
+		// Register a function that accepts a variable number of any arguments.
 		em.events[name] = append(em.events[name], func(event Event) error {
 			return em.callAnyVarHandler(handlerValue, event.Args())
 		})
 	} else {
+		// Register a function that accepts concrete argument types.
 		em.events[name] = append(em.events[name], func(event Event) error {
 			return em.callTypedHandler(handlerValue, event.Args())
 		})

--- a/events.go
+++ b/events.go
@@ -96,7 +96,7 @@ func (em *events) callTypedHandler(handler reflect.Value, args []any) error {
 		if !eventArgType.AssignableTo(handlerArgType) {
 			return fmt.Errorf(
 				"%w: type '%s' is not assignable to '%s' (index %d)",
-				HandlerTypeMismatchError, eventArgType, handlerArgType, index,
+				HandlerArgTypeMismatchError, eventArgType, handlerArgType, index,
 			)
 		}
 		handlerInArgs = append(handlerInArgs, reflect.ValueOf(eventArg))
@@ -163,5 +163,5 @@ func (e *event) Args() []any { return e.args }
 // anySliceType contains reflection type for any slice variable.
 var anySliceType = reflect.TypeOf((*[]any)(nil)).Elem()
 
-// HandlerTypeMismatchError declares handler type mismatch error.
-var HandlerTypeMismatchError = errors.New("handler type mismatch")
+// HandlerArgTypeMismatchError declares handler argument type mismatch error.
+var HandlerArgTypeMismatchError = errors.New("handler argument type mismatch")

--- a/events.go
+++ b/events.go
@@ -90,8 +90,11 @@ func (em *events) Trigger(event Event) error {
 func (em *events) callTypedHandler(handler reflect.Value, args []any) error {
 	// Prepare slice of in arguments for handler.
 	handlerInArgs := make([]reflect.Value, 0, handler.Type().NumIn())
-	for index, eventArg := range args {
-		eventArgType := reflect.TypeOf(eventArg)
+
+	// Fill handler args with provided event args.
+	maxArgsLen := min(len(args), handler.Type().NumIn())
+	for index := 0; index < maxArgsLen; index++ {
+		eventArgType := reflect.TypeOf(args[index])
 		handlerArgType := handler.Type().In(index)
 		if !eventArgType.AssignableTo(handlerArgType) {
 			return fmt.Errorf(
@@ -99,7 +102,16 @@ func (em *events) callTypedHandler(handler reflect.Value, args []any) error {
 				HandlerArgTypeMismatchError, eventArgType, handlerArgType, index,
 			)
 		}
-		handlerInArgs = append(handlerInArgs, reflect.ValueOf(eventArg))
+		eventArgValue := reflect.ValueOf(args[index])
+		handlerInArgs = append(handlerInArgs, eventArgValue)
+	}
+
+	// Fill handler args with default type values.
+	if len(handlerInArgs) < handler.Type().NumIn() {
+		for index := len(handlerInArgs); index < handler.Type().NumIn(); index++ {
+			zeroValuePtr := reflect.New(handler.Type().In(index))
+			handlerInArgs = append(handlerInArgs, zeroValuePtr.Elem())
+		}
 	}
 
 	// Invoke original event handler function.

--- a/events.go
+++ b/events.go
@@ -24,9 +24,6 @@ import (
 	"sync"
 )
 
-// HandlerTypeMismatchError declares handler type mismatch error.
-var HandlerTypeMismatchError = errors.New("handler type mismatch")
-
 // Events declares event broker type.
 type Events interface {
 	// Subscribe registers event handler.
@@ -165,3 +162,6 @@ func (e *event) Args() []any { return e.args }
 
 // anySliceType contains reflection type for any slice variable.
 var anySliceType = reflect.TypeOf((*[]any)(nil)).Elem()
+
+// HandlerTypeMismatchError declares handler type mismatch error.
+var HandlerTypeMismatchError = errors.New("handler type mismatch")

--- a/events_test.go
+++ b/events_test.go
@@ -10,6 +10,8 @@ func TestEvents(t *testing.T) {
 	testEvent1Args := [][]any(nil)
 	testEvent2Args := [][]any(nil)
 	testEvent3Args := [][]any(nil)
+	testEvent4Args := [][]any(nil)
+	testEvent5Args := [][]any(nil)
 
 	ev := &events{events: make(map[string][]handler)}
 	ev.Subscribe("TestEvent1", func(args ...any) {
@@ -23,14 +25,26 @@ func TestEvents(t *testing.T) {
 		testEvent3Args = append(testEvent3Args, []any{x, y, z})
 		return nil
 	})
+	ev.Subscribe("TestEvent4", func(x string, y int) error {
+		testEvent4Args = append(testEvent4Args, []any{x, y})
+		return nil
+	})
+	ev.Subscribe("TestEvent5", func(x string, y int, z bool) error {
+		testEvent5Args = append(testEvent5Args, []any{x, y, z})
+		return nil
+	})
 
 	equal(t, ev.Trigger(NewEvent("TestEvent1", 1)), nil)
 	equal(t, ev.Trigger(NewEvent("TestEvent1", "x")), nil)
 	equal(t, ev.Trigger(NewEvent("TestEvent2", true)), nil)
 	equal(t, ev.Trigger(NewEvent("TestEvent3", "x", 1, true)), nil)
+	equal(t, ev.Trigger(NewEvent("TestEvent4", "x", 1, true)), nil)
+	equal(t, ev.Trigger(NewEvent("TestEvent5", "x", 1)), nil)
 	equal(t, testEvent1Args, [][]any{{1}, {"x"}})
 	equal(t, testEvent2Args, [][]any{{true}})
 	equal(t, testEvent3Args, [][]any{{"x", 1, true}})
+	equal(t, testEvent4Args, [][]any{{"x", 1}})
+	equal(t, testEvent5Args, [][]any{{"x", 1, false}})
 }
 
 func equal(t *testing.T, a, b any) {

--- a/events_test.go
+++ b/events_test.go
@@ -9,8 +9,9 @@ import (
 func TestEvents(t *testing.T) {
 	testEvent1Args := [][]any(nil)
 	testEvent2Args := [][]any(nil)
+	testEvent3Args := [][]any(nil)
 
-	ev := make(events)
+	ev := &events{events: make(map[string][]handler)}
 	ev.Subscribe("TestEvent1", func(args ...any) {
 		testEvent1Args = append(testEvent1Args, args)
 	})
@@ -18,12 +19,18 @@ func TestEvents(t *testing.T) {
 		testEvent2Args = append(testEvent2Args, args)
 		return nil
 	})
+	ev.Subscribe("TestEvent3", func(x string, y int, z bool) error {
+		testEvent3Args = append(testEvent3Args, []any{x, y, z})
+		return nil
+	})
 
 	equal(t, ev.Trigger(NewEvent("TestEvent1", 1)), nil)
 	equal(t, ev.Trigger(NewEvent("TestEvent1", "x")), nil)
 	equal(t, ev.Trigger(NewEvent("TestEvent2", true)), nil)
+	equal(t, ev.Trigger(NewEvent("TestEvent3", "x", 1, true)), nil)
 	equal(t, testEvent1Args, [][]any{{1}, {"x"}})
 	equal(t, testEvent2Args, [][]any{{true}})
+	equal(t, testEvent3Args, [][]any{{"x", 1, true}})
 }
 
 func equal(t *testing.T, a, b any) {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/NVIDIA/gontainer
 
-go 1.20
+go 1.21

--- a/registry_test.go
+++ b/registry_test.go
@@ -20,7 +20,7 @@ func TestRegistryRegisterFactory(t *testing.T) {
 	opts := WithMetadata("test", func() {})
 	factory := NewFactory(fun, opts)
 
-	registry := &registry{events: events{}}
+	registry := &registry{}
 	equal(t, registry.registerFactory(ctx, factory), nil)
 	equal(t, registry.factories, []*Factory{factory})
 	equal(t, factory.factoryFunc == nil, false)
@@ -32,7 +32,7 @@ func TestRegistryStartFactories(t *testing.T) {
 	ctx := context.Background()
 	factory := NewFactory(func() bool { return true })
 
-	registry := &registry{events: events{}}
+	registry := &registry{}
 	equal(t, registry.registerFactory(ctx, factory), nil)
 	equal(t, registry.startFactories(), nil)
 	equal(t, factory.factorySpawned, true)


### PR DESCRIPTION
Previously, the event handler service in gontainer was quite primitive, allowing only one way to define an event handler with the `func(args ...any) [error]` signature. This approach is not convenient when working with well-defined types directly in the function signature, such as `func(arg1 string, arg2 int, arg3 bool) [error]`.

This pull request enhances the gontainer by adding support for typed event handlers. Now, developers can define event handlers with specific argument types, making the code more readable and type-safe.