### PR TITLE
Explicitly typed container errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,21 +256,21 @@ type Container interface {
 
 The service container emits several events during its lifecycle:
 
-| Event               | Description                                                                   |
-|---------------------|-------------------------------------------------------------------------------|
-| `ContainerStarting` | Emitted when the container's start method is invoked.                         |
-| `ContainerStarted`  | Emitted when the container's start method has completed.                      |
-| `ContainerClosing`  | Emitted when the container's close method is invoked.                         |
-| `ContainerClosed`   | Emitted when the container's close method has completed.                      |
-| `UnhandledPanic`    | Emitted when a panic occurs during container initialization, start, or close. |
+| <div style="width:200px">Event</div> | <div style="width:600px">Description</div>                                    |
+|--------------------------------------|-------------------------------------------------------------------------------|
+| `ContainerStarting`                  | Emitted when the container's start method is invoked.                         |
+| `ContainerStarted`                   | Emitted when the container's start method has completed.                      |
+| `ContainerClosing`                   | Emitted when the container's close method is invoked.                         |
+| `ContainerClosed`                    | Emitted when the container's close method has completed.                      |
+| `UnhandledPanic`                     | Emitted when a panic occurs during container initialization, start, or close. |
 
 ### Container Errors
 
 The service container may return the following errors, which can be checked using `errors.Is`:
 
-| Error                       | Description                                                                           |
-|-----------------------------|---------------------------------------------------------------------------------------|
-| `ErrFactoryReturnedError`   | Occurs when the factory function returns an error during invocation.                  |
-| `ErrServiceNotResolved`     | Occurs when resolving a service fails due to an unregistered service type.            |
-| `ErrHandlerArgTypeMismatch` | Occurs when an event handler's arguments do not match the event's expected arguments. |
-| `ErrStackLimitReached`      | Occurs when the service container encounters infinite recursion.                      |
+| <div style="width:200px">Error</div> | <div style="width:600px">Description</div>                                            |
+|--------------------------------------|---------------------------------------------------------------------------------------|
+| `ErrFactoryReturnedError`            | Occurs when the factory function returns an error during invocation.                  |
+| `ErrServiceNotResolved`              | Occurs when resolving a service fails due to an unregistered service type.            |
+| `ErrHandlerArgTypeMismatch`          | Occurs when an event handler's arguments do not match the event's expected arguments. |
+| `ErrStackLimitReached`               | Occurs when the service container encounters infinite recursion.                      |

--- a/README.md
+++ b/README.md
@@ -256,21 +256,21 @@ type Container interface {
 
 The service container emits several events during its lifecycle:
 
-| <div style="width:200px">Event</div> | <div style="width:600px">Description</div>                                    |
-|--------------------------------------|-------------------------------------------------------------------------------|
-| `ContainerStarting`                  | Emitted when the container's start method is invoked.                         |
-| `ContainerStarted`                   | Emitted when the container's start method has completed.                      |
-| `ContainerClosing`                   | Emitted when the container's close method is invoked.                         |
-| `ContainerClosed`                    | Emitted when the container's close method has completed.                      |
-| `UnhandledPanic`                     | Emitted when a panic occurs during container initialization, start, or close. |
+| Event               | Description                                                                   |
+|---------------------|-------------------------------------------------------------------------------|
+| `ContainerStarting` | Emitted when the container's start method is invoked.                         |
+| `ContainerStarted`  | Emitted when the container's start method has completed.                      |
+| `ContainerClosing`  | Emitted when the container's close method is invoked.                         |
+| `ContainerClosed`   | Emitted when the container's close method has completed.                      |
+| `UnhandledPanic`    | Emitted when a panic occurs during container initialization, start, or close. |
 
 ### Container Errors
 
 The service container may return the following errors, which can be checked using `errors.Is`:
 
-| <div style="width:200px">Error</div> | <div style="width:600px">Description</div>                                            |
-|--------------------------------------|---------------------------------------------------------------------------------------|
-| `ErrFactoryReturnedError`            | Occurs when the factory function returns an error during invocation.                  |
-| `ErrServiceNotResolved`              | Occurs when resolving a service fails due to an unregistered service type.            |
-| `ErrHandlerArgTypeMismatch`          | Occurs when an event handler's arguments do not match the event's expected arguments. |
-| `ErrStackLimitReached`               | Occurs when the service container encounters infinite recursion.                      |
+| Error                       | Description                                                                           |
+|-----------------------------|---------------------------------------------------------------------------------------|
+| `ErrFactoryReturnedError`   | Occurs when the factory function returns an error during invocation.                  |
+| `ErrServiceNotResolved`     | Occurs when resolving a service fails due to an unregistered service type.            |
+| `ErrHandlerArgTypeMismatch` | Occurs when an event handler's arguments do not match the event's expected arguments. |
+| `ErrStackLimitReached`      | Occurs when the service container encounters infinite recursion.                      |

--- a/README.md
+++ b/README.md
@@ -254,16 +254,23 @@ type Container interface {
 
 ### Container Events
 
-1. **ContainerStarting**: produced when container start method invoked. Synchronous.
-1. **ContainerStarted**: produced when container start method finished. Synchronous.
-1. **ContainerClosing**: produced when container close method invoked. Synchronous.
-1. **ContainerClosed**: produced when container close method finished. Synchronous.
-1. **UnhandledPanic**: produced when the panic is happened on container init, start or close.
+The service container emits several events during its lifecycle:
 
-### Container Lifecycle
+| Event               | Description                                                                   |
+|---------------------|-------------------------------------------------------------------------------|
+| `ContainerStarting` | Emitted when the container's start method is invoked.                         |
+| `ContainerStarted`  | Emitted when the container's start method has completed.                      |
+| `ContainerClosing`  | Emitted when the container's close method is invoked.                         |
+| `ContainerClosed`   | Emitted when the container's close method has completed.                      |
+| `UnhandledPanic`    | Emitted when a panic occurs during container initialization, start, or close. |
 
-1. **New**: The container is instantiated, and the reflection parsing of service factories is completed. The container ensures that service dependencies are resolved.
-1. **Starting**: Service factories are called to instantiate all service instances in container.
-1. **Started**: The container, along with all its services, are now fully operational.
-1. **Closing**: Upon receiving a close call or event, the container will invoke the `Close()` method on each service that has one, in the reverse order of their initialization.
-1. **Closed**: The container is fully terminated, and all resources have been released.
+### Container Errors
+
+The service container may return the following errors, which can be checked using `errors.Is`:
+
+| Error                       | Description                                                                           |
+|-----------------------------|---------------------------------------------------------------------------------------|
+| `ErrFactoryReturnedError`   | Occurs when the factory function returns an error during invocation.                  |
+| `ErrServiceNotResolved`     | Occurs when resolving a service fails due to an unregistered service type.            |
+| `ErrHandlerArgTypeMismatch` | Occurs when an event handler's arguments do not match the event's expected arguments. |
+| `ErrStackLimitReached`      | Occurs when the service container encounters infinite recursion.                      |

--- a/container.go
+++ b/container.go
@@ -96,7 +96,7 @@ func New(factories ...*Factory) (result Container, err error) {
 
 	// Register events broker instance in the registry.
 	if err := container.registry.registerFactory(ctx, NewService[Events](events)); err != nil {
-		return nil, fmt.Errorf("failed to register events service: %w", err)
+		return nil, fmt.Errorf("failed to register events manager: %w", err)
 	}
 
 	// Register service resolver instance in the registry.
@@ -265,7 +265,7 @@ func (c *container) Close() (err error) {
 	// Await container close, e.g. from concurrent close call.
 	<-c.ctx.Done()
 
-	return
+	return nil
 }
 
 // Done is closing after closing of all services.

--- a/events.go
+++ b/events.go
@@ -107,13 +107,13 @@ func (em *events) callTypedHandler(handler reflect.Value, args []any) error {
 		// Allow to pass only values which are not untyped nils.
 		if !eventArgValue.IsValid() {
 			return fmt.Errorf("%w: argument '%s' could not reveive type 'nil' (index %d)",
-				HandlerArgTypeMismatchError, handlerArgType, index)
+				ErrHandlerArgTypeMismatch, handlerArgType, index)
 		}
 
 		// Allow to pass only assignable to handler arg type values.
 		if !eventArgValue.Type().AssignableTo(handlerArgType) {
 			return fmt.Errorf("%w: argument '%s' could not reveive type '%s' (index %d)",
-				HandlerArgTypeMismatchError, handlerArgType, eventArgValue.Type(), index)
+				ErrHandlerArgTypeMismatch, handlerArgType, eventArgValue.Type(), index)
 		}
 
 		handlerInArgs = append(handlerInArgs, eventArgValue)
@@ -188,9 +188,6 @@ func (e *event) Args() []any { return e.args }
 // anySliceType contains reflection type for any slice variable.
 var anySliceType = reflect.TypeOf((*[]any)(nil)).Elem()
 
-// HandlerArgTypeMismatchError declares handler argument type mismatch error.
-var HandlerArgTypeMismatchError = errors.New("handler argument type mismatch")
-
 // isNillableType returns true whether the specified type kind could accept nil.
 func isNillableType(typ reflect.Type) bool {
 	switch typ.Kind() {
@@ -200,3 +197,6 @@ func isNillableType(typ reflect.Type) bool {
 		return false
 	}
 }
+
+// ErrHandlerArgTypeMismatch declares handler argument type mismatch error.
+var ErrHandlerArgTypeMismatch = errors.New("handler argument type mismatch")

--- a/events.go
+++ b/events.go
@@ -106,14 +106,18 @@ func (em *events) callTypedHandler(handler reflect.Value, args []any) error {
 
 		// Allow to pass only values which are not untyped nils.
 		if !eventArgValue.IsValid() {
-			return fmt.Errorf("%w: argument '%s' could not reveive type 'nil' (index %d)",
-				ErrHandlerArgTypeMismatch, handlerArgType, index)
+			return fmt.Errorf(
+				"%w: argument '%s' could not reveive type 'nil' (index %d)",
+				ErrHandlerArgTypeMismatch, handlerArgType, index,
+			)
 		}
 
 		// Allow to pass only assignable to handler arg type values.
 		if !eventArgValue.Type().AssignableTo(handlerArgType) {
-			return fmt.Errorf("%w: argument '%s' could not reveive type '%s' (index %d)",
-				ErrHandlerArgTypeMismatch, handlerArgType, eventArgValue.Type(), index)
+			return fmt.Errorf(
+				"%w: argument '%s' could not reveive type '%s' (index %d)",
+				ErrHandlerArgTypeMismatch, handlerArgType, eventArgValue.Type(), index,
+			)
 		}
 
 		handlerInArgs = append(handlerInArgs, eventArgValue)

--- a/factory.go
+++ b/factory.go
@@ -95,7 +95,7 @@ func (f *Factory) Metadata() FactoryMetadata {
 // load initializes factory definition internal values.
 func (f *Factory) load(ctx context.Context) error {
 	if f.factoryLoaded {
-		return errors.New("invalid factory func: already loaded")
+		return fmt.Errorf("%w: already loaded", ErrFactoryFuncInvalid)
 	}
 
 	// Prepare cancellable context for the factory services.
@@ -103,14 +103,14 @@ func (f *Factory) load(ctx context.Context) error {
 
 	// Check factory configured.
 	if f.factoryFunc == nil {
-		return errors.New("invalid factory func: no func specified")
+		return fmt.Errorf("%w: no func specified", ErrFactoryFuncInvalid)
 	}
 
 	// Validate factory type and signature.
 	f.factoryType = reflect.TypeOf(f.factoryFunc)
 	f.factoryValue = reflect.ValueOf(f.factoryFunc)
 	if f.factoryType.Kind() != reflect.Func {
-		return fmt.Errorf("invalid factory func: not a function: %s", f.factoryType)
+		return fmt.Errorf("%w: not a function: %s", ErrFactoryFuncInvalid, f.factoryType)
 	}
 
 	// Index factory input types from the function signature.
@@ -202,3 +202,6 @@ func splitFuncName(funcFullName string) (string, string) {
 	funcName := strings.Join(fullNameChunks[lastPackageChunkIndex+1:], ".")
 	return packageName, funcName
 }
+
+// ErrFactoryFuncInvalid declares invalid factory func error.
+var ErrFactoryFuncInvalid = errors.New("invalid factory func")

--- a/factory.go
+++ b/factory.go
@@ -95,7 +95,7 @@ func (f *Factory) Metadata() FactoryMetadata {
 // load initializes factory definition internal values.
 func (f *Factory) load(ctx context.Context) error {
 	if f.factoryLoaded {
-		return fmt.Errorf("%w: already loaded", ErrFactoryFuncInvalid)
+		return errors.New("invalid factory func: already loaded")
 	}
 
 	// Prepare cancellable context for the factory services.
@@ -103,14 +103,14 @@ func (f *Factory) load(ctx context.Context) error {
 
 	// Check factory configured.
 	if f.factoryFunc == nil {
-		return fmt.Errorf("%w: no func specified", ErrFactoryFuncInvalid)
+		return errors.New("invalid factory func: no func specified")
 	}
 
 	// Validate factory type and signature.
 	f.factoryType = reflect.TypeOf(f.factoryFunc)
 	f.factoryValue = reflect.ValueOf(f.factoryFunc)
 	if f.factoryType.Kind() != reflect.Func {
-		return fmt.Errorf("%w: not a function: %s", ErrFactoryFuncInvalid, f.factoryType)
+		return fmt.Errorf("invalid factory func: not a function: %s", f.factoryType)
 	}
 
 	// Index factory input types from the function signature.
@@ -202,6 +202,3 @@ func splitFuncName(funcFullName string) (string, string) {
 	funcName := strings.Join(fullNameChunks[lastPackageChunkIndex+1:], ".")
 	return packageName, funcName
 }
-
-// ErrFactoryFuncInvalid declares invalid factory func error.
-var ErrFactoryFuncInvalid = errors.New("invalid factory func")

--- a/registry.go
+++ b/registry.go
@@ -340,11 +340,11 @@ func getStackDepth() int {
 // stackDepthLimit to protect from infinite recursion.
 const stackDepthLimit = 100
 
-// ErrStackLimitReached declares a reach of stack limit error.
-var ErrStackLimitReached = errors.New("stack limit reached")
-
 // ErrFactoryReturnedError declares factory returned an error.
 var ErrFactoryReturnedError = errors.New("factory returned an error")
 
 // ErrServiceNotResolved declares service not resolved error.
 var ErrServiceNotResolved = errors.New("service not resolved")
+
+// ErrStackLimitReached declares a reach of stack limit error.
+var ErrStackLimitReached = errors.New("stack limit reached")

--- a/registry_test.go
+++ b/registry_test.go
@@ -52,7 +52,7 @@ func TestRegistryStartWithErrors(t *testing.T) {
 	equal(t, err != nil, true)
 	equal(t, fmt.Sprint(err), `failed to spawn services of `+
 		`Factory[func() (bool, error)] from 'github.com/NVIDIA/gontainer': `+
-		`failed to invoke factory func: failed to create new service`)
+		`failed to invoke factory: failed to create new service`)
 }
 
 // TestRegistryCloseFactories tests corresponding registry method.
@@ -101,7 +101,7 @@ func TestRegistryCloseWithError(t *testing.T) {
 	err := registry.closeServices()
 	equal(t, err != nil, true)
 	equal(t, fmt.Sprint(err), `failed to close services: `+
-		`Factory[func() interface {}] from 'github.com/NVIDIA/gontainer': failed to close 2; `+
+		`Factory[func() interface {}] from 'github.com/NVIDIA/gontainer': failed to close 2`+"\n"+
 		`Factory[func(context.Context) interface {}] from 'github.com/NVIDIA/gontainer': failed to close 1`)
 }
 

--- a/registry_test.go
+++ b/registry_test.go
@@ -52,7 +52,7 @@ func TestRegistryStartWithErrors(t *testing.T) {
 	equal(t, err != nil, true)
 	equal(t, fmt.Sprint(err), `failed to spawn services of `+
 		`Factory[func() (bool, error)] from 'github.com/NVIDIA/gontainer': `+
-		`failed to invoke factory: failed to create new service`)
+		`factory returned an error: failed to create new service`)
 }
 
 // TestRegistryCloseFactories tests corresponding registry method.

--- a/resolver.go
+++ b/resolver.go
@@ -9,7 +9,7 @@ import (
 // Resolver defines service resolver interface.
 type Resolver interface {
 	// Resolve returns specified dependency.
-	Resolve(any) error
+	Resolve(varPtr any) error
 }
 
 // resolver implements resolver interface.
@@ -23,7 +23,7 @@ func (r *resolver) Resolve(varPtr any) error {
 	value := reflect.ValueOf(varPtr).Elem()
 	result, err := r.registry.resolveService(value.Type())
 	if err != nil {
-		return fmt.Errorf("failed to get service: %s", err)
+		return fmt.Errorf("failed to resolve service: %w", err)
 	}
 	value.Set(result)
 	return nil


### PR DESCRIPTION
Defined error consts.

* `ErrFactoryReturnedError` when the factory function returns an error on invocation.
* `ErrServiceNotResolved` when resolve of a service failed in case of not registered type.
* `ErrHandlerArgTypeMismatch` when the event handler has inconsistent arguments with an event.
* `ErrStackLimitReached` when the service container faces infinite recursion.