### PR TITLE
Improvement and refactoring of service functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ func (s *MyService) Close() error {
 ### Service Functions
 
 The **Service Function** is a specialized form of service optimized for simpler tasks. Instead of returning a concrete
-type object or an interface, the service factory returns a function that conforms to `func() error` type.
+type object or an interface, the service factory returns a function that conforms to `func() error` or `func()` type.
 
 The function serves two primary roles:
 
@@ -196,8 +196,8 @@ The function serves two primary roles:
 
 ```go
 // MyServiceFactory is an example of a service function usage.
-func MyServiceFactory(ctx context.Context) func () error {
-    return func () error {
+func MyServiceFactory(ctx context.Context) func() error {
+    return func() error {
         // Await its order in container close.
         <-ctx.Done()
       

--- a/container_test.go
+++ b/container_test.go
@@ -58,6 +58,7 @@ func TestContainerLifecycle(t *testing.T) {
 			dep7 interface{ Do5() error },
 			dep8 Optional[testService5],
 			dep9 Optional[interface{ Do5() error }],
+			dep10 Optional[func() error],
 		) any {
 			equal(t, dep1, float64(100500))
 			equal(t, dep2, "string")
@@ -70,6 +71,7 @@ func TestContainerLifecycle(t *testing.T) {
 			equal(t, dep8.Get()().Error(), "svc5 error")
 			equal(t, dep8.Get().Do5().Error(), "svc5 error")
 			equal(t, dep9.Get().Do5().Error(), "svc5 error")
+			equal(t, dep10.Get(), (func() error)(nil))
 			factoryStarted.Store(true)
 
 			// Service function.

--- a/container_test.go
+++ b/container_test.go
@@ -19,6 +19,7 @@ package gontainer
 
 import (
 	"context"
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -34,6 +35,9 @@ func TestContainerLifecycle(t *testing.T) {
 	svc2 := &testService2{}
 	svc3 := &testService3{}
 	svc4 := &testService4{}
+	svc5 := testService5(func() error {
+		return fmt.Errorf("svc5 error")
+	})
 
 	container, err := New(
 		NewService(float64(100500)),
@@ -42,19 +46,33 @@ func TestContainerLifecycle(t *testing.T) {
 		NewFactory(func() *testService1 { return svc1 }),
 		NewFactory(func() *testService2 { return svc2 }),
 		NewFactory(func() (*testService3, *testService4) { return svc3, svc4 }),
+		NewFactory(func() testService5 { return svc5 }),
 		NewFactory(func(
 			ctx context.Context,
-			dep1 float64, dep2 string,
+			dep1 float64,
+			dep2 string,
 			dep3 Optional[int],
 			dep4 Optional[bool],
 			dep5 Multiple[interface{ Do2() }],
+			dep6 testService5,
+			dep7 interface{ Do5() error },
+			dep8 Optional[testService5],
+			dep9 Optional[interface{ Do5() error }],
 		) any {
 			equal(t, dep1, float64(100500))
 			equal(t, dep2, "string")
 			equal(t, dep3.Get(), 123)
 			equal(t, dep4.Get(), false)
 			equal(t, dep5, Multiple[interface{ Do2() }]{svc1, svc2})
+			equal(t, dep6().Error(), "svc5 error")
+			equal(t, dep6.Do5().Error(), "svc5 error")
+			equal(t, dep7.Do5().Error(), "svc5 error")
+			equal(t, dep8.Get()().Error(), "svc5 error")
+			equal(t, dep8.Get().Do5().Error(), "svc5 error")
+			equal(t, dep9.Get().Do5().Error(), "svc5 error")
 			factoryStarted.Store(true)
+
+			// Service function.
 			return func() error {
 				serviceStarted.Store(true)
 				<-ctx.Done()
@@ -67,7 +85,7 @@ func TestContainerLifecycle(t *testing.T) {
 	equal(t, container == nil, false)
 
 	// Assert factories and services.
-	equal(t, len(container.Factories()), 10)
+	equal(t, len(container.Factories()), 11)
 	equal(t, len(container.Services()), 0)
 
 	// Start all factories in the container.
@@ -76,8 +94,8 @@ func TestContainerLifecycle(t *testing.T) {
 	equal(t, serviceClosed.Load(), false)
 
 	// Assert factories and services.
-	equal(t, len(container.Factories()), 10)
-	equal(t, len(container.Services()), 12)
+	equal(t, len(container.Factories()), 11)
+	equal(t, len(container.Services()), 13)
 
 	// Let factory function start executing in the background.
 	time.Sleep(time.Millisecond)
@@ -90,10 +108,14 @@ func TestContainerLifecycle(t *testing.T) {
 	equal(t, serviceClosed.Load(), true)
 
 	// Assert context is closed.
-	<-container.Done()
+	select {
+	case <-container.Done():
+	default:
+		t.Fatalf("context is not closed")
+	}
 
 	// Assert factories and services.
-	equal(t, len(container.Factories()), 10)
+	equal(t, len(container.Factories()), 11)
 	equal(t, len(container.Services()), 0)
 }
 
@@ -115,3 +137,7 @@ func (t *testService3) Do1() {}
 type testService4 struct{}
 
 func (t *testService4) Do1() {}
+
+type testService5 func() error
+
+func (t testService5) Do5() error { return t() }

--- a/events_test.go
+++ b/events_test.go
@@ -82,6 +82,7 @@ func TestEvents(t *testing.T) {
 }
 
 func equal(t *testing.T, a, b any) {
+	t.Helper()
 	if !reflect.DeepEqual(a, b) {
 		t.Fatalf("equal failed: '%v' != '%v'", a, b)
 	}

--- a/registry.go
+++ b/registry.go
@@ -377,10 +377,12 @@ func (r *registry) spawnFactory(factory *Factory) error {
 
 	// Handle factory out functions as regular objects.
 	for factoryOutIndex, factoryOutValue := range factoryOutValues {
-		var err error
-		factoryOutValues[factoryOutIndex], err = wrapFactoryFunc(factoryOutValue)
-		if err != nil {
-			return fmt.Errorf("failed to wrap factory func: %w", err)
+		if serviceFuncValue, ok := isServiceFunc(factoryOutValue); ok {
+			if serviceFuncResult, err := startServiceFunc(serviceFuncValue); err == nil {
+				factoryOutValues[factoryOutIndex] = serviceFuncResult
+			} else {
+				return fmt.Errorf("failed to start factory func: %w", err)
+			}
 		}
 	}
 
@@ -395,11 +397,11 @@ func (r *registry) spawnFactory(factory *Factory) error {
 	return nil
 }
 
-// function represents service function return value wrapper.
-type function chan error
+// function represents service func return value wrapper.
+type funcResult chan error
 
 // Close awaits service function and returns result error.
-func (f function) Close() error {
+func (f funcResult) Close() error {
 	return <-f
 }
 
@@ -420,36 +422,59 @@ func isContextInterface(typ reflect.Type) bool {
 	return typ.Kind() == reflect.Interface && typ.Implements(ctxType)
 }
 
-// wrapFactoryFunc wraps specified function to the regular service object.
-func wrapFactoryFunc(factoryOutValue reflect.Value) (reflect.Value, error) {
-	// Check specified factory out value elem is a function.
-	// The factoryOutValue can be an `any` type with a function in the value,
-	// when the factory declares any return type, or directly a function type,
-	// when the factory declares explicit func return type. Both cases are OK.
-	if factoryOutValue.Kind() == reflect.Interface {
-		if factoryOutValue.Elem().Kind() == reflect.Func {
-			factoryOutValue = factoryOutValue.Elem()
+// isServiceFunc returns true when the argument is a service function.
+// The `factoryOutValue` can be an `any` type with a function in the value
+// (when the factory declares `any` return type), or the `function` type
+// (when the factory declares explicit return type).
+func isServiceFunc(factoryOutValue reflect.Value) (reflect.Value, bool) {
+	// Unbox the value if it is an any interface.
+	if isEmptyInterface(factoryOutValue.Type()) {
+		factoryOutValue = factoryOutValue.Elem()
+	}
+
+	// Check if the result value kind is a func kind.
+	// The func type must have no user-defined methods,
+	// because otherwise it could be a service instance
+	// based on the func type but implements an interface.
+	if factoryOutValue.Kind() == reflect.Func {
+		if factoryOutValue.NumMethod() == 0 {
+			return factoryOutValue, true
 		}
 	}
-	if factoryOutValue.Kind() != reflect.Func {
-		return factoryOutValue, nil
+
+	return reflect.Value{}, false
+}
+
+// startServiceFunc wraps service function to the regular service object.
+func startServiceFunc(serviceFuncValue reflect.Value) (reflect.Value, error) {
+	// Prepare closable result chan as a service function replacement.
+	// The service function result error will be returned from the
+	// result wrapper chan `Close() error` method right to the
+	// service container on the termination stage.
+	funcResultChan := funcResult(make(chan error))
+
+	// Start the service function in background.
+	serviceFunc := serviceFuncValue.Interface()
+	switch serviceFunc := serviceFunc.(type) {
+	case func() error:
+		go func() {
+			err := serviceFunc()
+			funcResultChan <- err
+		}()
+	case func():
+		go func() {
+			serviceFunc()
+			funcResultChan <- nil
+		}()
+	default:
+		return reflect.Value{}, fmt.Errorf(
+			"unexpected service function signature: %T",
+			serviceFuncValue.Interface(),
+		)
 	}
-
-	// Check specified factory out value is a service function.
-	// It is a programming error, if the function has wrong interface.
-	factoryOutServiceFn, ok := factoryOutValue.Interface().(func() error)
-	if !ok {
-		return factoryOutValue, fmt.Errorf("unexpected signature '%s'", factoryOutValue.Type())
-	}
-
-	// Prepare a regular object from the function.
-	fnResult := function(make(chan error))
-
-	// Run specified function in background and await for return.
-	go func() { fnResult <- factoryOutServiceFn() }()
 
 	// Return reflected value of the wrapper.
-	return reflect.ValueOf(fnResult), nil
+	return reflect.ValueOf(funcResultChan), nil
 }
 
 // errorType contains reflection type for error variable.

--- a/registry.go
+++ b/registry.go
@@ -378,11 +378,11 @@ func (r *registry) spawnFactory(factory *Factory) error {
 	// Handle factory out functions as regular objects.
 	for factoryOutIndex, factoryOutValue := range factoryOutValues {
 		if serviceFuncValue, ok := isServiceFunc(factoryOutValue); ok {
-			if serviceFuncResult, err := startServiceFunc(serviceFuncValue); err == nil {
-				factoryOutValues[factoryOutIndex] = serviceFuncResult
-			} else {
+			serviceFuncResult, err := startServiceFunc(serviceFuncValue)
+			if err != nil {
 				return fmt.Errorf("failed to start factory func: %w", err)
 			}
+			factoryOutValues[factoryOutIndex] = serviceFuncResult
 		}
 	}
 


### PR DESCRIPTION
Improvement and refactoring of service functions.

1. Additional simplified signature of service functions added `func()` in addition to signature `func() error`.
2. New service function requirement added: it must have no receiver methods to distinguish it from user types based on a func kind. Otherwise, this function will be treated as a regular service, will not be wrapped and started in background.