### PR TITLE
Factory instantiation modes support

### DIFF
--- a/factory.go
+++ b/factory.go
@@ -61,6 +61,15 @@ type FactoryFunc any
 // integration with external tools. It is populated using `WithMetadata()` option.
 type FactoryMetadata map[string]any
 
+// FactoryInstMode configures services instantiation mode for this factory.
+type factoryInstMode int
+
+// A factory can produce types once or always, depending on the mode.
+const (
+	factoryInstModeOnce factoryInstMode = iota
+	factoryInstModeAlways
+)
+
 // Factory declares a service factory definition used by the container to construct services.
 //
 // A Factory wraps a factory function along with its metadata, input/output type information,
@@ -80,6 +89,9 @@ type Factory struct {
 
 	// Factory metadata.
 	factoryMetadata FactoryMetadata
+
+	// Factory instantiation mode.
+	factoryInstMode factoryInstMode
 
 	// Factory is loaded.
 	factoryLoaded bool
@@ -241,6 +253,26 @@ func NewFactory(factoryFn FactoryFunc, opts ...FactoryOpt) *Factory {
 func WithMetadata(key string, value any) FactoryOpt {
 	return func(factory *Factory) {
 		factory.factoryMetadata[key] = value
+	}
+}
+
+// WithInstantiateOnce sets the factory to instantiate new instances only once
+// when the service is requested at first time (lazy mode without container start)
+// or when the factory is invoked on the eager container start.
+// This is the default behavior.
+func WithInstantiateOnce() FactoryOpt {
+	return func(factory *Factory) {
+		factory.factoryInstMode = factoryInstModeOnce
+	}
+}
+
+// WithInstantiateAlways sets the factory to instantiate new instances every time:
+//   - for every dependency injection;
+//   - for every resolution via resolver service;
+//   - for every resolution via invoker service.
+func WithInstantiateAlways() FactoryOpt {
+	return func(factory *Factory) {
+		factory.factoryInstMode = factoryInstModeAlways
 	}
 }
 

--- a/factory_test.go
+++ b/factory_test.go
@@ -119,6 +119,24 @@ func TestFactoryMetadata(t *testing.T) {
 	})
 }
 
+// TestFactoryInstantiateDefault tests factory instantiation once (default).
+func TestFactoryInstantiateDefault(t *testing.T) {
+	factory := NewFactory(func() {})
+	equal(t, factory.factoryInstMode, factoryInstModeOnce)
+}
+
+// TestFactoryInstantiateOnce tests factory instantiation once (explicit).
+func TestFactoryInstantiateOnce(t *testing.T) {
+	factory := NewFactory(func() {}, WithInstantiateOnce())
+	equal(t, factory.factoryInstMode, factoryInstModeOnce)
+}
+
+// testFactoryInstantiateAlways tests factory instantiation always.
+func TestFactoryInstantiateAlways(t *testing.T) {
+	factory := NewFactory(func() {}, WithInstantiateAlways())
+	equal(t, factory.factoryInstMode, factoryInstModeAlways)
+}
+
 type globalType struct{}
 
 func globalFunc(string) {}

--- a/registry.go
+++ b/registry.go
@@ -335,8 +335,8 @@ func (r *registry) spawnFactory(factory *Factory) error {
 		return ErrStackLimitReached
 	}
 
-	// Check factory already spawned.
-	if factory.factorySpawned {
+	// Check factory already spawned and should not be respawned always.
+	if factory.factorySpawned && factory.factoryInstMode == factoryInstModeOnce {
 		return nil
 	}
 

--- a/registry_test.go
+++ b/registry_test.go
@@ -214,6 +214,66 @@ func TestRegistryProduceServices(t *testing.T) {
 	equal(t, result.Interface(), true)
 }
 
+// TestRegistryResolveByTypeOnce tests corresponding registry method.
+func TestRegistryResolveByTypeOnce(t *testing.T) {
+	factoryInvocations := 0
+	ctx := context.Background()
+	factory := NewFactory(
+		func() bool {
+			factoryInvocations++
+			return true
+		},
+		WithInstantiateOnce(),
+	)
+
+	registry := &registry{}
+	equal(t, registry.registerFactory(ctx, factory), nil)
+
+	resolve := func() bool {
+		typ := reflect.TypeOf(true)
+		value, err := registry.resolveByType(typ)
+		equal(t, err, nil)
+		equal(t, len(value), 1)
+		equal(t, factory.factorySpawned, true)
+		return value[0].Interface().(bool)
+	}
+
+	equal(t, resolve(), true)
+	equal(t, resolve(), true)
+	equal(t, resolve(), true)
+	equal(t, factoryInvocations, 1)
+}
+
+// TestRegistryResolveByTypeAlways tests corresponding registry method.
+func TestRegistryResolveByTypeAlways(t *testing.T) {
+	factoryInvocations := 0
+	ctx := context.Background()
+	factory := NewFactory(
+		func() bool {
+			factoryInvocations++
+			return true
+		},
+		WithInstantiateAlways(),
+	)
+
+	registry := &registry{}
+	equal(t, registry.registerFactory(ctx, factory), nil)
+
+	resolve := func() bool {
+		typ := reflect.TypeOf(true)
+		value, err := registry.resolveByType(typ)
+		equal(t, err, nil)
+		equal(t, len(value), 1)
+		equal(t, factory.factorySpawned, true)
+		return value[0].Interface().(bool)
+	}
+
+	equal(t, resolve(), true)
+	equal(t, resolve(), true)
+	equal(t, resolve(), true)
+	equal(t, factoryInvocations, 3)
+}
+
 // TestRegistryProduceWithErrors tests corresponding registry method.
 func TestRegistryProduceWithErrors(t *testing.T) {
 	registry := &registry{}


### PR DESCRIPTION
* `WithInstantiateOnce()` option to instantiate as in past, whether all services are singletons.
* `WithInstantiateAlways()` option to instantiate always new instances on every service request.