### PR TITLE
V2 devel: support for the container root context

### DIFF
--- a/container.go
+++ b/container.go
@@ -25,15 +25,11 @@ import (
 
 // New returns new container instance with a set of configured services.
 // The `factories` specifies factories for services with dependency resolution.
-func New(factories ...*Factory) (result *Container, err error) {
-	// Don't accept the context in args, since it mustn't be cancelled outside.
-	// Cancel of the root context will trigger cancel of all children contexts, but
-	// it is unwanted behavior: services should be cancelled in strict reverse order.
-
-	// Prepare container context.
+func New(ctx context.Context, factories ...*Factory) (result *Container, err error) {
+	// Prepare container context ignoring the cancelling.
 	// When cancelled, it closes `container.Done()` channel
 	// and unblocks any waiting read from `container.Done()`.
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 
 	// Cancel context only when returning an error.
 	// Otherwise, in will be cancelled by container.

--- a/container_test.go
+++ b/container_test.go
@@ -39,6 +39,7 @@ func TestContainerLifecycle(t *testing.T) {
 	})
 
 	container, err := New(
+		context.Background(),
 		NewService(float64(100500)),
 		NewFactory(func() string { return "string" }),
 		NewFactory(func() (int, int64) { return 123, 456 }),

--- a/examples/01_console_command/main.go
+++ b/examples/01_console_command/main.go
@@ -18,6 +18,7 @@
 package main
 
 import (
+	"context"
 	"log"
 
 	"github.com/NVIDIA/gontainer"
@@ -48,6 +49,9 @@ func main() {
 	// Order of factories definition is non-restrictive.
 	log.Println("Creating new service container")
 	container, err := gontainer.New(
+		// Root context for container.
+		context.Background(),
+
 		// Factory to create an instance of NameService.
 		gontainer.NewFactory(func() *NameService {
 			return &NameService{name: "Bob"}

--- a/examples/02_daemon_service/main.go
+++ b/examples/02_daemon_service/main.go
@@ -54,6 +54,9 @@ func main() {
 	// Order of factories definition is non-restrictive.
 	log.Println("Creating service container instance")
 	container, err := gontainer.New(
+		// Root context for container.
+		context.Background(),
+
 		// Inject singleton object.
 		gontainer.NewService(logger),
 

--- a/examples/03_complete_webapp/main.go
+++ b/examples/03_complete_webapp/main.go
@@ -18,6 +18,7 @@
 package main
 
 import (
+	"context"
 	"os"
 
 	"github.com/NVIDIA/gontainer"
@@ -37,6 +38,9 @@ func init() {
 func main() {
 	// Initialize the service container.
 	container, err := gontainer.New(
+		// Root context for container.
+		context.Background(),
+
 		// Enable config service.
 		config.WithConfig(),
 

--- a/examples/04_transient_services/main.go
+++ b/examples/04_transient_services/main.go
@@ -18,6 +18,7 @@
 package main
 
 import (
+	"context"
 	"log"
 
 	"github.com/NVIDIA/gontainer"
@@ -28,6 +29,9 @@ func main() {
 	// Order of factories definition is non-restrictive.
 	log.Println("Creating new service container")
 	container, err := gontainer.New(
+		// Root context for container.
+		context.Background(),
+
 		// Return a function that returns an int.
 		gontainer.NewFactory(func() func() int {
 			// From the container perspective this is a regular service.

--- a/invoker_test.go
+++ b/invoker_test.go
@@ -18,6 +18,7 @@
 package gontainer
 
 import (
+	"context"
 	"errors"
 	"testing"
 )
@@ -97,6 +98,7 @@ func TestInvokerService(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			container, err := New(
+				context.Background(),
 				NewFactory(func() string { return "string" }),
 				NewFactory(func() int { return 123 }),
 			)

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -18,12 +18,14 @@
 package gontainer
 
 import (
+	"context"
 	"testing"
 )
 
 // TestResolverService tests resolver service.
 func TestResolverService(t *testing.T) {
 	container, err := New(
+		context.Background(),
 		NewFactory(func() string { return "string" }),
 		NewFactory(func(resolver *Resolver) {
 			var depExists string


### PR DESCRIPTION
This pull request updates the construction of the service container to require an explicit context. All usages of `New` in examples and tests have been updated to pass a root context, and the container implementation now ignores external cancellation, ensuring services are cancelled in strict reverse order.

**Container context handling:**

* The signature of `New` in `container.go` now requires a `context.Context` argument, and uses `context.WithoutCancel` to prevent unwanted external cancellation of the container context.

**Examples update:**

* All example files (`main.go` in `examples/01_console_command`, `examples/02_daemon_service`, `examples/03_complete_webapp`, `examples/04_transient_services`) now import `context` and pass `context.Background()` as the root context when creating a container. [[1]](diffhunk://#diff-aeeaf3883448a89ac0c0e17bd2ad35d1f5921f2080fd41728fcf2bb0b3889789R21) [[2]](diffhunk://#diff-aeeaf3883448a89ac0c0e17bd2ad35d1f5921f2080fd41728fcf2bb0b3889789R52-R54) [[3]](diffhunk://#diff-4fb90c3fe40c80e8fb4b126f0075a5bbed6e14144eafbd1c549a655e430a12feR57-R59) [[4]](diffhunk://#diff-37fa79737982ae151ec4b0c41e5bee41486bf7cdc2b99f1093271e088ee7756dR21) [[5]](diffhunk://#diff-37fa79737982ae151ec4b0c41e5bee41486bf7cdc2b99f1093271e088ee7756dR41-R43) [[6]](diffhunk://#diff-28131f7cb8ae4b4088a6363f39aa778435d26179a078c36d5a3b3a56c629a1a8R21) [[7]](diffhunk://#diff-28131f7cb8ae4b4088a6363f39aa778435d26179a078c36d5a3b3a56c629a1a8R32-R34)

**Tests update:**

* All test files (`container_test.go`, `invoker_test.go`, `resolver_test.go`) now import `context` and pass `context.Background()` to the `New` function, ensuring tests use the updated API. [[1]](diffhunk://#diff-b1eb9afa48ad78a73fcc18342b9da970021b71d1eb6cf6e391a80012a31cbfd3R42) [[2]](diffhunk://#diff-b94afd8f2b61900f3e2589c5034cde0e920eed8942b19ad5f58c119e4f40503bR21) [[3]](diffhunk://#diff-b94afd8f2b61900f3e2589c5034cde0e920eed8942b19ad5f58c119e4f40503bR101) [[4]](diffhunk://#diff-cae42b84ca10542ef0fe0dc7c38f20bded0108d3f271f309fcf4600c070f2521R21-R28)

These changes ensure consistent and safer context management throughout the codebase.