### PR TITLE
V2 devel: rid of the container services API

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,9 +277,6 @@ func (c *Container) Done() <-chan struct{}
 // Factories returns all registered service factories.
 func (c *Container) Factories() []*Factory
 
-// Services returns all currently instantiated services.
-func (c *Container) Services() []any
-
 // Resolver returns a service resolver for on-demand dependency injection.
 // If container is not started, only requested services
 // will be spawned on `resolver.Resolve(...)` call.

--- a/container.go
+++ b/container.go
@@ -196,28 +196,6 @@ func (c *Container) Factories() []*Factory {
 	return factories
 }
 
-// Services returns all currently instantiated services.
-func (c *Container) Services() []any {
-	// Acquire read lock.
-	c.mutex.RLock()
-	defer c.mutex.RUnlock()
-
-	select {
-	case <-c.ctx.Done():
-		return nil
-	default:
-		services := make([]any, 0, len(c.registry.factories))
-		for _, factory := range c.registry.factories {
-			if factory.getSpawned() {
-				for _, serviceValue := range factory.getOutValues() {
-					services = append(services, serviceValue.Interface())
-				}
-			}
-		}
-		return services
-	}
-}
-
 // Resolver returns a service resolver for on-demand dependency injection.
 // If the container is not yet started, only requested services and their
 // transitive dependencies will be instantiated.

--- a/container_test.go
+++ b/container_test.go
@@ -79,20 +79,11 @@ func TestContainerLifecycle(t *testing.T) {
 	)
 	equal(t, err, nil)
 	equal(t, container == nil, false)
-
-	// Assert factories and services.
 	equal(t, len(container.Factories()), 10)
-	equal(t, len(container.Services()), 0)
 
 	// Start all factories in the container.
 	equal(t, container.Start(), nil)
 	equal(t, factoryStarted.Load(), true)
-	equal(t, serviceClosed.Load(), false)
-
-	// Assert factories and services.
-	equal(t, len(container.Factories()), 10)
-	equal(t, len(container.Services()), 12)
-
 	equal(t, serviceClosed.Load(), false)
 
 	// Close all factories in the container.
@@ -105,10 +96,6 @@ func TestContainerLifecycle(t *testing.T) {
 	default:
 		t.Fatalf("context is not closed")
 	}
-
-	// Assert factories and services.
-	equal(t, len(container.Factories()), 10)
-	equal(t, len(container.Services()), 0)
 }
 
 type testService1 struct{}


### PR DESCRIPTION
This pull request removes the `Services` method from the `Container` type and eliminates all associated usage and tests. The main focus is on simplifying the container API by no longer exposing a way to list all currently instantiated services.

API simplification:

* Removed the `Services` method from the `Container` type in `container.go`, eliminating the ability to retrieve all instantiated services.
* Deleted the corresponding documentation for the `Services` method from `README.md`.

Test cleanup:

* Removed all assertions and tests related to the `Services` method from `container_test.go`, including checks for service counts before and after container lifecycle events. [[1]](diffhunk://#diff-b1eb9afa48ad78a73fcc18342b9da970021b71d1eb6cf6e391a80012a31cbfd3L82-L97) [[2]](diffhunk://#diff-b1eb9afa48ad78a73fcc18342b9da970021b71d1eb6cf6e391a80012a31cbfd3L108-L111)