### PR TITLE
V2 devel: simplification of the resolver and invoker methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,16 @@ Dependency injection service container for Golang projects.
    ```
    or
    ```go
-   if err := container.Invoke(func(myService *MyService) {
+   values, err := container.Invoke(func(myService *MyService) error {
        myService.SayHello("World")
-   }); err != nil {
+       return nil
+   })
+   if err != nil {
        log.Fatalf("Failed to invoke a function: %s", err)
+   }
+   // Check function's returned error
+   if values[0] != nil {
+       log.Fatalf("Function returned error: %s", values[0])
    }
    ```
    The `Resolve` and `Invoke` methods can serve as an entry point to the application, especially when it's a simple console tool that runs a task and exits.
@@ -283,9 +289,10 @@ func (c *Container) Factories() []*Factory
 func (c *Container) Resolve(varPtr any) error
 
 // Invoke calls the provided function with auto-injected dependencies.
-// If the container is not yet started, only requested services and their
-// transitive dependencies will be instantiated.
-func (c *Container) Invoke(fn any) (*InvokeResult, error)
+// Returns all values returned by the function as []any, and an error if
+// dependency resolution fails. If the container is not yet started, only 
+// requested services and their transitive dependencies will be instantiated.
+func (c *Container) Invoke(fn any) ([]any, error)
 ```
 
 ### Container Errors

--- a/README.md
+++ b/README.md
@@ -106,23 +106,23 @@ Dependency injection service container for Golang projects.
       log.Fatalf("Failed to start service container: %s", err)
    }
    ```
-5. Alternatively to eager start with a `Start()` call it is possible to use `Resolver` or `Invoker` service. They will instantiate only the explicitly requested services and their transitive dependencies.
+5. Alternatively to eager start with a `Start()` call it is possible to resolve services on-demand. They will instantiate only the explicitly requested services and their transitive dependencies.
    ```go
    var myService *MyService
-   if err := container.Resolver().Resolve(&myService); err != nil {
+   if err := container.Resolve(&myService); err != nil {
        log.Fatalf("Failed to resolve dependency: %s", err)
    }
    myService.SayHello("World")
    ```
    or
    ```go
-   if err := container.Invoker().Invoke(func(myService *MyService) {
+   if err := container.Invoke(func(myService *MyService) {
        myService.SayHello("World")
    }); err != nil {
        log.Fatalf("Failed to invoke a function: %s", err)
    }
    ```
-   `Resolver` and `Invoker` could also serve as an entry point to the application, especially when it's a simple console tool that runs a task and exits.
+   The `Resolve` and `Invoke` methods can serve as an entry point to the application, especially when it's a simple console tool that runs a task and exits.
    The [console command example](./examples/01_console_command/main.go) demonstrates this approach.
 
 ## Key Concepts
@@ -277,15 +277,15 @@ func (c *Container) Done() <-chan struct{}
 // Factories returns all registered service factories.
 func (c *Container) Factories() []*Factory
 
-// Resolver returns a service resolver for on-demand dependency injection.
-// If container is not started, only requested services
-// will be spawned on `resolver.Resolve(...)` call.
-func (c *Container) Resolver() *Resolver
+// Resolve resolves a service dependency and stores it in the provided pointer.
+// If the container is not yet started, only requested services and their
+// transitive dependencies will be instantiated.
+func (c *Container) Resolve(varPtr any) error
 
-// Invoker returns a function invoker that can call user-provided functions
-// with auto-injected dependencies. If container is not started, only requested 
-// services will be spawned to invoke the func.
-func (c *Container) Invoker() *Invoker
+// Invoke calls the provided function with auto-injected dependencies.
+// If the container is not yet started, only requested services and their
+// transitive dependencies will be instantiated.
+func (c *Container) Invoke(fn any) (*InvokeResult, error)
 ```
 
 ### Container Errors

--- a/container.go
+++ b/container.go
@@ -150,7 +150,6 @@ func (c *Container) Start() (resultErr error) {
 // Close shuts down all services in reverse order of their instantiation.
 // This method blocks until all services are properly closed.
 func (c *Container) Close() (err error) {
-
 	// Acquire write lock.
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
@@ -196,33 +195,18 @@ func (c *Container) Factories() []*Factory {
 	return factories
 }
 
-// Resolver returns a service resolver for on-demand dependency injection.
+// Resolve resolves a service dependency and stores it in the provided pointer.
+// The varPtr must be a pointer to the variable where the resolved service will be stored.
 // If the container is not yet started, only requested services and their
 // transitive dependencies will be instantiated.
-func (c *Container) Resolver() *Resolver {
-	// Acquire read lock.
-	c.mutex.RLock()
-	defer c.mutex.RUnlock()
-
-	select {
-	case <-c.ctx.Done():
-		return nil
-	default:
-		return c.resolver
-	}
+func (c *Container) Resolve(varPtr any) error {
+	return c.resolver.Resolve(varPtr)
 }
 
-// Invoker returns a function invoker that can call user-provided functions
-// with auto-injected dependencies. Behaves lazily if the container is not started.
-func (c *Container) Invoker() *Invoker {
-	// Acquire read lock.
-	c.mutex.RLock()
-	defer c.mutex.RUnlock()
-
-	select {
-	case <-c.ctx.Done():
-		return nil
-	default:
-		return c.invoker
-	}
+// Invoke calls the provided function with auto-injected dependencies.
+// The function's arguments will be resolved from the container.
+// If the container is not yet started, only requested services and their
+// transitive dependencies will be instantiated.
+func (c *Container) Invoke(fn any) (*InvokeResult, error) {
+	return c.invoker.Invoke(fn)
 }

--- a/container.go
+++ b/container.go
@@ -200,6 +200,10 @@ func (c *Container) Factories() []*Factory {
 // If the container is not yet started, only requested services and their
 // transitive dependencies will be instantiated.
 func (c *Container) Resolve(varPtr any) error {
+	// Acquire read lock.
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
 	return c.resolver.Resolve(varPtr)
 }
 
@@ -207,6 +211,11 @@ func (c *Container) Resolve(varPtr any) error {
 // The function's arguments will be resolved from the container.
 // If the container is not yet started, only requested services and their
 // transitive dependencies will be instantiated.
-func (c *Container) Invoke(fn any) (*InvokeResult, error) {
+func (c *Container) Invoke(fn any) ([]any, error) {
+	// Acquire read lock.
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	// Invoke the function.
 	return c.invoker.Invoke(fn)
 }

--- a/examples/01_console_command/main.go
+++ b/examples/01_console_command/main.go
@@ -80,9 +80,9 @@ func main() {
 		log.Println("Service container closed")
 	}()
 
-	// Application entrypoint using the `Invoker` service.
-	// Invoker will resolve all dependencies for the function.
-	_, err = container.Invoker().Invoke(func(svc *HelloService) {
+	// Application entrypoint using container.Invoke.
+	// It will resolve all dependencies for the function.
+	_, err = container.Invoke(func(svc *HelloService) {
 		// Here the application bootstrap code could be located.
 		// It can access all services from the container.
 		// For example, HTTP server could be started here.
@@ -94,10 +94,10 @@ func main() {
 
 	// - or -
 
-	// Application entrypoint using the `Resolver` service.
-	// This code will manually resolve all dependencies.
+	// Application entrypoint using container.Resolve.
+	// This code will manually resolve the dependency.
 	var helloService *HelloService
-	err = container.Resolver().Resolve(&helloService)
+	err = container.Resolve(&helloService)
 	if err != nil {
 		log.Panicf("Failed to resolve: %s", err)
 	}

--- a/examples/01_console_command/main.go
+++ b/examples/01_console_command/main.go
@@ -82,7 +82,7 @@ func main() {
 
 	// Application entrypoint using container.Invoke.
 	// It will resolve all dependencies for the function.
-	_, err = container.Invoke(func(svc *HelloService) {
+	values, err := container.Invoke(func(svc *HelloService) {
 		// Here the application bootstrap code could be located.
 		// It can access all services from the container.
 		// For example, HTTP server could be started here.
@@ -91,6 +91,8 @@ func main() {
 	if err != nil {
 		log.Panicf("Failed to invoke: %s", err)
 	}
+	// values is empty since the function returns nothing
+	_ = values
 
 	// - or -
 

--- a/invoker.go
+++ b/invoker.go
@@ -30,23 +30,19 @@ import (
 // If the container has not been started yet, dependency resolution happens in lazy mode — only
 // the required arguments and their transitive dependencies are instantiated on demand.
 //
-// The function may have one of the following return signatures:
-//   - no return values (i.e., `func(...)`),
-//   - a single `error` (i.e., `func(...) error`),
-//   - multiple return values, where the last one may be an `error` (i.e., `func(...) (T1, T2, ..., error)`).
+// The Invoke method returns:
+//   - []any - all values returned by the function (including any errors)
+//   - error - only if dependency resolution fails or fn is not a function
 //
-// If the last return value implements the `error` interface and is non-nil, it is returned.
-// All other return values are collected into the InvokeResult.
-//
-// An error is also returned if:
-//   - `fn` is not a function,
-//   - any dependency could not be resolved.
+// All return values from the invoked function are collected in the []any slice,
+// including any error values. The caller is responsible for checking and handling
+// these values as appropriate.
 type Invoker struct {
 	resolver *Resolver
 }
 
 // Invoke invokes specified function.
-func (i *Invoker) Invoke(fn any) (*InvokeResult, error) {
+func (i *Invoker) Invoke(fn any) ([]any, error) {
 	// Get reflection of the fn.
 	fnValue := reflect.ValueOf(fn)
 	if fnValue.Kind() != reflect.Func {
@@ -63,42 +59,12 @@ func (i *Invoker) Invoke(fn any) (*InvokeResult, error) {
 		fnInArgs = append(fnInArgs, fnArgPtrValue.Elem())
 	}
 
-	// Convert function results.
+	// Call the function and collect results.
 	fnOutArgs := fnValue.Call(fnInArgs)
-	result := &InvokeResult{
-		values: make([]any, 0, len(fnOutArgs)),
-		err:    nil,
-	}
-	for index, fnOut := range fnOutArgs {
-		// If it is the last return value.
-		if index == len(fnOutArgs)-1 {
-			// And type of the value is the error.
-			if fnOut.Type().Implements(errorType) {
-				// Use the value as an error.
-				// Ignore failed cast of nil error.
-				result.err, _ = fnOut.Interface().(error)
-			}
-		}
-
-		// Add value to the results slice.
-		result.values = append(result.values, fnOut.Interface())
+	values := make([]any, 0, len(fnOutArgs))
+	for _, fnOut := range fnOutArgs {
+		values = append(values, fnOut.Interface())
 	}
 
-	return result, nil
-}
-
-// InvokeResult provides access to the invocation result.
-type InvokeResult struct {
-	values []any
-	err    error
-}
-
-// Values returns a slice of function result values.
-func (r *InvokeResult) Values() []any {
-	return r.values
-}
-
-// Error returns function result error, if any.
-func (r *InvokeResult) Error() error {
-	return r.err
+	return values, nil
 }

--- a/invoker_test.go
+++ b/invoker_test.go
@@ -108,7 +108,7 @@ func TestInvokerService(t *testing.T) {
 				equal(t, container.Close(), nil)
 			}()
 
-			result, err := container.Invoker().Invoke(tt.haveFn)
+			result, err := container.Invoke(tt.haveFn)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Invoke() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/invoker_test.go
+++ b/invoker_test.go
@@ -28,15 +28,14 @@ func TestInvokerService(t *testing.T) {
 	tests := []struct {
 		name    string
 		haveFn  any
-		wantFn  func(t *testing.T, value *InvokeResult)
+		wantFn  func(t *testing.T, values []any)
 		wantErr bool
 	}{
 		{
 			name:   "ReturnNothing",
 			haveFn: func(var1 string, var2 int) {},
-			wantFn: func(t *testing.T, value *InvokeResult) {
-				equal(t, len(value.Values()), 0)
-				equal(t, value.Error(), nil)
+			wantFn: func(t *testing.T, values []any) {
+				equal(t, len(values), 0)
 			},
 			wantErr: false,
 		},
@@ -45,27 +44,25 @@ func TestInvokerService(t *testing.T) {
 			haveFn: func(var1 string, var2 int) (string, int, bool) {
 				return var1 + "-X", var2 + 100, true
 			},
-			wantFn: func(t *testing.T, value *InvokeResult) {
-				equal(t, len(value.Values()), 3)
-				equal(t, value.Values()[0], "string-X")
-				equal(t, value.Values()[1], 223)
-				equal(t, value.Values()[2], true)
-				equal(t, value.Error(), nil)
+			wantFn: func(t *testing.T, values []any) {
+				equal(t, len(values), 3)
+				equal(t, values[0], "string-X")
+				equal(t, values[1], 223)
+				equal(t, values[2], true)
 			},
 			wantErr: false,
 		},
 		{
-			name: "ReturnNoValuesWithError",
+			name: "ReturnValuesWithError",
 			haveFn: func(var1 string, var2 int) (string, int, error) {
 				return var1 + "-X", var2 + 100, errors.New("failed")
 			},
-			wantFn: func(t *testing.T, value *InvokeResult) {
-				equal(t, len(value.Values()), 3)
-				equal(t, value.Values()[0], "string-X")
-				equal(t, value.Values()[1], 223)
-				equal(t, value.Values()[2].(error).Error(), "failed")
-				equal(t, value.Error().Error(), "failed")
-				equal(t, value.Error(), value.Values()[2])
+			wantFn: func(t *testing.T, values []any) {
+				equal(t, len(values), 3)
+				equal(t, values[0], "string-X")
+				equal(t, values[1], 223)
+				// Error is returned as a regular value
+				equal(t, values[2].(error).Error(), "failed")
 			},
 			wantErr: false,
 		},
@@ -74,23 +71,20 @@ func TestInvokerService(t *testing.T) {
 			haveFn: func(var1 string, var2 int) (error, error, error) {
 				return nil, errors.New("error-1"), errors.New("error-2")
 			},
-			wantFn: func(t *testing.T, value *InvokeResult) {
-				equal(t, len(value.Values()), 3)
-				equal(t, value.Values()[0], nil)
-				equal(t, value.Values()[1].(error).Error(), "error-1")
-				equal(t, value.Values()[2].(error).Error(), "error-2")
-				equal(t, value.Error().Error(), "error-2")
-				equal(t, value.Error(), value.Values()[2])
+			wantFn: func(t *testing.T, values []any) {
+				equal(t, len(values), 3)
+				equal(t, values[0], nil)
+				equal(t, values[1].(error).Error(), "error-1")
+				equal(t, values[2].(error).Error(), "error-2")
 			},
 			wantErr: false,
 		},
 		{
 			name:   "ReturnNilError",
 			haveFn: func(var1 string, var2 int) error { return nil },
-			wantFn: func(t *testing.T, value *InvokeResult) {
-				equal(t, len(value.Values()), 1)
-				equal(t, value.Values()[0], nil)
-				equal(t, value.Error(), nil)
+			wantFn: func(t *testing.T, values []any) {
+				equal(t, len(values), 1)
+				equal(t, values[0], nil)
 			},
 			wantErr: false,
 		},
@@ -108,13 +102,13 @@ func TestInvokerService(t *testing.T) {
 				equal(t, container.Close(), nil)
 			}()
 
-			result, err := container.Invoke(tt.haveFn)
+			values, err := container.Invoke(tt.haveFn)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Invoke() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if tt.wantFn != nil {
-				tt.wantFn(t, result)
+				tt.wantFn(t, values)
 			}
 		})
 	}

--- a/registry.go
+++ b/registry.go
@@ -402,12 +402,6 @@ func isEmptyInterface(typ reflect.Type) bool {
 	return typ.Kind() == reflect.Interface && typ.NumMethod() == 0
 }
 
-// isErrorInterface returns true when argument is an `error` interface.
-func isErrorInterface(typ reflect.Type) bool {
-	ctxType := reflect.TypeOf((*error)(nil)).Elem()
-	return typ.Kind() == reflect.Interface && typ.Implements(ctxType)
-}
-
 // isContextInterface returns true when argument is a context interface.
 func isContextInterface(typ reflect.Type) bool {
 	ctxType := reflect.TypeOf((*context.Context)(nil)).Elem()


### PR DESCRIPTION
This pull request refactors the dependency injection container API to simplify service resolution and invocation. The previous `Resolver` and `Invoker` methods are replaced with direct `Resolve` and `Invoke` methods on the `Container`, making the API more straightforward and easier to use. Documentation, examples, and tests have been updated to reflect these changes.

**API simplification and modernization:**

* Replaced `Resolver()` and `Invoker()` methods on the `Container` with direct `Resolve(varPtr any)` and `Invoke(fn any)` methods, streamlining service resolution and function invocation. (`container.go`, [container.goL199-R211](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL199-R211))
* Updated documentation in `README.md` to describe the new `Resolve` and `Invoke` methods, removing references to `Resolver` and `Invoker`. (`README.md`, [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L109-R125) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L280-R288)

**Examples and tests update:**

* Refactored example usage in `examples/01_console_command/main.go` to use `container.Resolve` and `container.Invoke` instead of the old methods. [[1]](diffhunk://#diff-aeeaf3883448a89ac0c0e17bd2ad35d1f5921f2080fd41728fcf2bb0b3889789L83-R85) [[2]](diffhunk://#diff-aeeaf3883448a89ac0c0e17bd2ad35d1f5921f2080fd41728fcf2bb0b3889789L97-R100)
* Updated unit tests in `invoker_test.go` to use `container.Invoke` for function invocation.

**Minor cleanup:**

* Removed unnecessary blank line in the `Close` method for consistency. (`container.go`, [container.goL153](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL153))