### PR TITLE
V2 devel: stricter factory interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,31 +136,21 @@ Dependency injection service container for Golang projects.
 ### Service Factories
 
 The **Service Factory** is a key component of the service container, serving as a mechanism for creating service instances.
-A service factory is essentially a function that accepts other services as arguments and returns one or more service instances,
+A service factory is essentially a function that accepts other services as arguments and returns one service instance,
 optionally along with an error. Using service factory signature, the service container will resolve and spawn all dependency
 services using reflection and fail, if there are unresolvable dependencies.
 
 ```go
-// MyServiceFactory is an example of a service factory.
-func MyServiceFactory( /* service dependencies */) *MyService {
-   // Initialize service instance.
-   return new(MyService)
-}
-
 // MyServiceFactory depends on two services.
-func MyServiceFactory(svc1 MyService1, svc2 MyService2) MyService {...}
+func MyServiceFactory(svc1 *MyService1, svc2 *MyService2) *MyService {...}
 
-// MyServiceFactory provides two services.
-func MyServiceFactory() (MyService1, MyService2) {...}
+// MyServiceFactory returns a service with error handling.
+func MyServiceFactory() (*MyService, error) {...}
 
-// MyServiceFactory provides two services and return an error.
-func MyServiceFactory() (MyService1, MyService2, error) {...}
-
-// MyServiceFactory returns only an error.
-func MyServiceFactory() error {...}
-
-// MyServiceFactory provides nothing.
-func MyServiceFactory() {...}
+// Invalid patterns - these will be rejected:
+// func() (*Service1, *Service2) {...}         // Multiple outputs not allowed
+// func() error {...}                          // Must return exactly one service
+// func() {...}                                // Must return exactly one service
 ```
 
 The factory function's role is to perform any necessary initializations and return a fully-configured service instance

--- a/container.go
+++ b/container.go
@@ -58,14 +58,14 @@ func New(ctx context.Context, factories ...*Factory) (result *Container, err err
 	}
 
 	// Register service resolver instance in the registry.
-	if factory, err := NewService[*Resolver](resolver).factory(); err != nil {
+	if factory, err := NewService(resolver).factory(); err != nil {
 		return nil, fmt.Errorf("failed to register service resolver: %w", err)
 	} else {
 		registry.registerFactory(factory)
 	}
 
 	// Register function invoker instance in the registry.
-	if factory, err := NewService[*Invoker](invoker).factory(); err != nil {
+	if factory, err := NewService(invoker).factory(); err != nil {
 		return nil, fmt.Errorf("failed to register function invoker: %w", err)
 	} else {
 		registry.registerFactory(factory)
@@ -114,10 +114,9 @@ type Container struct {
 	registry *registry
 }
 
-// Start initializes all registered services in dependency order.
-// Services are instantiated via their factories.
-// Returns an error if initialization fails.
+// Start initializes all registered services.
 func (c *Container) Start() (resultErr error) {
+	// Recover from panics during the start process.
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			_ = c.Close()
@@ -147,7 +146,8 @@ func (c *Container) Start() (resultErr error) {
 	return nil
 }
 
-// Close shuts down all services in reverse order of their instantiation.
+// Close closes the service container and all services.
+// Services close order is reverse to the instantiation order.
 // This method blocks until all services are properly closed.
 func (c *Container) Close() (err error) {
 	// Acquire write lock.

--- a/container.go
+++ b/container.go
@@ -52,9 +52,9 @@ func New(ctx context.Context, factories ...*Factory) (result *Container, err err
 	container := &Container{
 		ctx:      ctx,
 		cancel:   cancel,
+		registry: registry,
 		resolver: resolver,
 		invoker:  invoker,
-		registry: registry,
 	}
 
 	// Register service resolver instance in the registry.
@@ -104,14 +104,14 @@ type Container struct {
 	closer sync.Once
 	mutex  sync.RWMutex
 
+	// Services registry.
+	registry *registry
+
 	// Service resolver.
 	resolver *Resolver
 
 	// Function invoker.
 	invoker *Invoker
-
-	// Services registry.
-	registry *registry
 }
 
 // Start initializes all registered services.

--- a/container_test.go
+++ b/container_test.go
@@ -25,11 +25,8 @@ import (
 	"testing"
 )
 
-// TestContainerLifecycle tests container lifecycle.
-func TestContainerLifecycle(t *testing.T) {
-	factoryStarted := atomic.Bool{}
-	serviceClosed := atomic.Bool{}
-
+// TestContainer tests service container.
+func TestContainer(t *testing.T) {
 	svc1 := &testService1{}
 	svc2 := &testService2{}
 	svc3 := &testService3{}
@@ -38,14 +35,17 @@ func TestContainerLifecycle(t *testing.T) {
 		return fmt.Errorf("svc5 error")
 	})
 
+	started := atomic.Bool{}
 	container, err := New(
 		context.Background(),
 		NewService(float64(100500)),
 		NewFactory(func() string { return "string" }),
-		NewFactory(func() (int, int64) { return 123, 456 }),
+		NewFactory(func() int { return 123 }),
+		NewFactory(func() int64 { return 456 }),
 		NewFactory(func() *testService1 { return svc1 }),
 		NewFactory(func() *testService2 { return svc2 }),
-		NewFactory(func() (*testService3, *testService4) { return svc3, svc4 }),
+		NewFactory(func() *testService3 { return svc3 }),
+		NewFactory(func() *testService4 { return svc4 }),
 		NewFactory(func() testService5 { return svc5 }),
 		NewFactory(func(
 			ctx context.Context,
@@ -59,7 +59,7 @@ func TestContainerLifecycle(t *testing.T) {
 			dep8 Optional[testService5],
 			dep9 Optional[interface{ Do5() error }],
 			dep10 Optional[func() error],
-		) any {
+		) float32 {
 			equal(t, dep1, float64(100500))
 			equal(t, dep2, "string")
 			equal(t, dep3.Get(), 123)
@@ -72,23 +72,21 @@ func TestContainerLifecycle(t *testing.T) {
 			equal(t, dep8.Get().Do5().Error(), "svc5 error")
 			equal(t, dep9.Get().Do5().Error(), "svc5 error")
 			equal(t, dep10.Get(), (func() error)(nil))
-			factoryStarted.Store(true)
-
-			return &testServiceWithClose{ctx: ctx, closed: &serviceClosed}
+			started.Store(true)
+			return 123
 		}),
 	)
 	equal(t, err, nil)
 	equal(t, container == nil, false)
-	equal(t, len(container.Factories()), 10)
+	equal(t, len(container.Factories()), 12)
+	equal(t, started.Load(), false)
 
 	// Start all factories in the container.
 	equal(t, container.Start(), nil)
-	equal(t, factoryStarted.Load(), true)
-	equal(t, serviceClosed.Load(), false)
+	equal(t, started.Load(), true)
 
 	// Close all factories in the container.
 	equal(t, container.Close(), nil)
-	equal(t, serviceClosed.Load(), true)
 
 	// Assert context is closed.
 	select {

--- a/factory.go
+++ b/factory.go
@@ -29,31 +29,7 @@ import (
 
 // FactoryFunc declares the type for a service factory function.
 // A factory function may accept dependencies as input parameters and
-// return zero or more service instances, optionally followed by an error.
-// The container validates its signature at runtime using reflection.
-//
-// Valid example signatures:
-//
-//	// No dependencies, no produced services.
-//	func()
-//
-//	// No dependencies, one produced service.
-//	func() *MyService
-//
-//	// One dependency, one produced service, an error.
-//	func(db *Database) (*Repo, error)
-//
-//	// Multiple dependencies, multiple produced services, an error.
-//	func(log *slog.Logger, db *Database) (*Repo1, *Repo2, error)
-//
-//	// Multiple dependencies, multiple produced services, no error.
-//	func(log *slog.Logger, db *Database) (*Repo1, *Repo2, *Repo3)
-//
-//	// One optional dependency, one produced service, an error.
-//	func(optionalDB gontainer.Optional[*Database]) (*Repo, error)
-//
-//	// One multiple dependency, one produced service, an error.
-//	func(multipleDBs gontainer.Multiple[IDatabase]) (*Repo, error)
+// must return exactly one service, optionally followed by an error.
 type FactoryFunc any
 
 // FactoryMetadata defines a key-value store for attaching metadata to a factory.
@@ -104,14 +80,14 @@ func (f *Factory) Metadata() FactoryMetadata {
 func (f *Factory) factory() (*factory, error) {
 	// Check factory configured.
 	if f.fn == nil {
-		return nil, errors.New("invalid factory func: no func specified")
+		return nil, errors.New("func is nil")
 	}
 
 	// Validate factory type and signature.
 	funcType := reflect.TypeOf(f.fn)
 	funcValue := reflect.ValueOf(f.fn)
 	if funcType.Kind() != reflect.Func {
-		return nil, fmt.Errorf("invalid factory func: not a function: %s", funcType)
+		return nil, fmt.Errorf("invalid type: %s", funcType)
 	}
 
 	// Index factory input types from the function signature.
@@ -122,15 +98,21 @@ func (f *Factory) factory() (*factory, error) {
 
 	// Index factory output types from the function signature.
 	outTypes := make([]reflect.Type, 0, funcType.NumOut())
-	outError := false
 	for index := 0; index < funcType.NumOut(); index++ {
-		if index != funcType.NumOut()-1 || funcType.Out(index) != errorType {
-			// Register regular factory output type.
-			outTypes = append(outTypes, funcType.Out(index))
-		} else {
-			// Register last output index as an error.
-			outError = true
-		}
+		outTypes = append(outTypes, funcType.Out(index))
+	}
+
+	// Validate factory output types.
+	switch {
+	// Factory returns exactly one service.
+	case len(outTypes) == 1 && !isEmptyInterface(outTypes[0]):
+
+	// Factory returns a service and an error.
+	case len(outTypes) == 2 && !isEmptyInterface(outTypes[0]) && isErrorInterface(outTypes[1]):
+
+	// Factory has invalid out signature.
+	default:
+		return nil, fmt.Errorf("invalid signature: %s", funcType)
 	}
 
 	// Prepare cancellable context for the factory services.
@@ -145,8 +127,7 @@ func (f *Factory) factory() (*factory, error) {
 		funcType:  funcType,
 		funcValue: funcValue,
 		inTypes:   inTypes,
-		outTypes:  outTypes,
-		outError:  outError,
+		outType:   outTypes[0],
 	}, nil
 }
 
@@ -285,14 +266,11 @@ type factory struct {
 	// Factory input types.
 	inTypes []reflect.Type
 
-	// Factory output types.
-	outTypes []reflect.Type
+	// Factory output type.
+	outType reflect.Type
 
-	// Factory output error.
-	outError bool
-
-	// Factory result values.
-	outValues []reflect.Value
+	// Factory output value.
+	outValue reflect.Value
 }
 
 // getSpawned returns factory spawned status in a thread-safe way.
@@ -309,16 +287,16 @@ func (f *factory) setSpawned(value bool) {
 	f.spawned = value
 }
 
-// getOutValues returns factory output values in a thread-safe way.
-func (f *factory) getOutValues() []reflect.Value {
+// getOutValue returns factory output value in a thread-safe way.
+func (f *factory) getOutValue() reflect.Value {
 	f.mutex.RLock()
 	defer f.mutex.RUnlock()
-	return f.outValues
+	return f.outValue
 }
 
-// setOutValues sets factory output values in a thread-safe way.
-func (f *factory) setOutValues(values []reflect.Value) {
+// setOutValue sets factory output value in a thread-safe way.
+func (f *factory) setOutValue(value reflect.Value) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
-	f.outValues = values
+	f.outValue = value
 }

--- a/factory_test.go
+++ b/factory_test.go
@@ -24,26 +24,20 @@ import (
 
 // TestFactoryLoad tests factory loading.
 func TestFactoryLoad(t *testing.T) {
-	fun := func(a, b, c string) (int, bool, error) {
-		return 1, true, nil
+	fun := func(a, b, c string) (int, error) {
+		return 100500, nil
 	}
 
-	opts := WithMetadata("test", "value")
-	factory := NewFactory(fun, opts)
+	factory := NewFactory(fun)
 	state, err := factory.factory()
-	equal(t, err, nil)
 
-	equal(t, factory.metadata["test"], "value")
-	equal(t, factory.fn == nil, false)
-	equal(t, state.spawned, false)
-	equal(t, state.ctx != nil, true)
-	equal(t, state.cancel != nil, true)
-	equal(t, state.funcType.String(), "func(string, string, string) (int, bool, error)")
-	equal(t, state.funcValue.String(), "<func(string, string, string) (int, bool, error) Value>")
+	equal(t, err, nil)
+	equal(t, state.funcType.String(), "func(string, string, string) (int, error)")
+	equal(t, state.funcValue.String(), "<func(string, string, string) (int, error) Value>")
 	equal(t, fmt.Sprint(state.inTypes), "[string string string]")
-	equal(t, fmt.Sprint(state.outTypes), "[int bool]")
-	equal(t, state.outError, true)
-	equal(t, len(state.outValues), 0)
+	equal(t, fmt.Sprint(state.outType), "int")
+	equal(t, state.spawned, false)
+	equal(t, state.outValue.IsValid(), false)
 }
 
 // TestFactoryInfo tests factories info.

--- a/registry.go
+++ b/registry.go
@@ -66,7 +66,7 @@ func (r *registry) validateFactories() error {
 			}
 
 			// Is a factory for this type could be resolved?
-			typeFactories, _ := r.findFactoriesFor(inType)
+			typeFactories := r.findFactoriesFor(inType)
 			if len(typeFactories) == 0 {
 				errs = append(errs, fmt.Errorf(
 					"failed to validate argument '%s' (index %d) of factory '%s' from '%s': %w",
@@ -79,20 +79,13 @@ func (r *registry) validateFactories() error {
 
 	// Validate all output types are unique.
 	for _, factory := range r.factories {
-		for index, outType := range factory.outTypes {
-			// Factories returning `any` could be duplicated.
-			if isEmptyInterface(outType) {
-				continue
-			}
-
-			// Validate uniqueness of the every factory output type.
-			typeFactories, _ := r.findFactoriesFor(outType)
-			if len(typeFactories) > 1 {
-				errs = append(errs, fmt.Errorf(
-					"failed to validate output '%s' (index %d) of factory '%s' from '%s': %w",
-					outType, index, factory.source.name, factory.source.source, ErrServiceDuplicated,
-				))
-			}
+		// Validate uniqueness of the factory output type.
+		typeFactories := r.findFactoriesFor(factory.outType)
+		if len(typeFactories) > 1 {
+			errs = append(errs, fmt.Errorf(
+				"failed to validate output '%s' of factory '%s' from '%s': %w",
+				factory.outType, factory.source.name, factory.source.source, ErrServiceDuplicated,
+			))
 		}
 	}
 
@@ -123,7 +116,7 @@ func (r *registry) validateFactories() error {
 				}
 
 				// Walk through all factories for this in argument type.
-				typeFactories, _ := r.findFactoriesFor(inType)
+				typeFactories := r.findFactoriesFor(inType)
 				for _, factoryForType := range typeFactories {
 					if factoryForType == r.factories[index] {
 						errs = append(errs, fmt.Errorf(
@@ -178,25 +171,24 @@ func (r *registry) closeFactories() error {
 		// the waiting of context done channel and finish work.
 		factory.cancel()
 
-		// Handle every spawned factory output value.
-		for outIndex, outValue := range factory.getOutValues() {
-			// Get the factory result object interface.
-			service := outValue.Interface()
+		// Handle the single spawned factory output value.
+		outValue := factory.getOutValue()
+		// Get the factory result object interface.
+		service := outValue.Interface()
 
-			// Close service implementing `Close() error` interface.
-			if closer, ok := service.(interface{ Close() error }); ok {
-				if err := closer.Close(); err != nil {
-					errs = append(errs, fmt.Errorf(
-						"failed to close service '%s' (index %d) of factory '%s' from '%s': %w",
-						outValue.Type(), outIndex, factory.source.name, factory.source.source, err),
-					)
-				}
+		// Close service implementing `Close() error` interface.
+		if closer, ok := service.(interface{ Close() error }); ok {
+			if err := closer.Close(); err != nil {
+				errs = append(errs, fmt.Errorf(
+					"failed to close service '%s' of factory '%s' from '%s': %w",
+					outValue.Type(), factory.source.name, factory.source.source, err),
+				)
 			}
+		}
 
-			// Close service implementing `Close()` interface.
-			if closer, ok := service.(interface{ Close() }); ok {
-				closer.Close()
-			}
+		// Close service implementing `Close()` interface.
+		if closer, ok := service.(interface{ Close() }); ok {
+			closer.Close()
 		}
 	}
 
@@ -278,57 +270,45 @@ func (r *registry) resolveRegular(serviceType reflect.Type) (reflect.Value, erro
 // resolveByType resolves all service fits to specified type.
 func (r *registry) resolveByType(serviceType reflect.Type) ([]reflect.Value, error) {
 	// Lookup factory definition by an output service type.
-	factories, outIndexes := r.findFactoriesFor(serviceType)
+	factories := r.findFactoriesFor(serviceType)
 	services := make([]reflect.Value, 0, len(factories))
 
-	for index, factory := range factories {
+	for _, factory := range factories {
 		// Handle found factory definition.
 		if err := r.spawnFactory(factory); err != nil {
 			return nil, fmt.Errorf("failed to spawn factory '%s': %w", factory.funcType, err)
 		}
 
-		// Handle services from factory outputs.
-		outValues := factory.getOutValues()
-		for _, outIndex := range outIndexes[index] {
-			services = append(services, outValues[outIndex])
-		}
+		// Handle service from factory output (single value).
+		services = append(services, factory.getOutValue())
 	}
 
 	return services, nil
 }
 
 // findFactoriesFor lookups for all factories for an output type in the registry.
-func (r *registry) findFactoriesFor(serviceType reflect.Type) ([]*factory, [][]int) {
+func (r *registry) findFactoriesFor(serviceType reflect.Type) []*factory {
 	var records []*factory
-	var indices [][]int
 
 	// Lookup for factories in the registry.
 	for _, record := range r.factories {
-		var indexes []int
-		for index, resultType := range record.outTypes {
-			// If requested type matched.
-			if resultType == serviceType {
+		// Desired service type matched.
+		if record.outType == serviceType {
+			records = append(records, record)
+			continue
+		}
+
+		// Desired service type implements an interface.
+		if serviceType.Kind() == reflect.Interface {
+			if record.outType.Implements(serviceType) {
 				records = append(records, record)
-				indexes = append(indexes, index)
 				continue
 			}
-
-			// if requested type implements a non-empty interface.
-			if isNonEmptyInterface(serviceType) {
-				if resultType.Implements(serviceType) {
-					records = append(records, record)
-					indexes = append(indexes, index)
-					continue
-				}
-			}
-		}
-		if len(indexes) > 0 {
-			indices = append(indices, indexes)
 		}
 	}
 
-	// Return matched factories and indices.
-	return records, indices
+	// Return matched factories.
+	return records
 }
 
 // spawnFactory instantiates specified factory definition.
@@ -362,19 +342,12 @@ func (r *registry) spawnFactory(factory *factory) error {
 		inValues = append(inValues, inValue)
 	}
 
-	// Spawn the factory using the factory input arguments.
+	// Spawn the factory using input arguments.
 	outValues := factory.funcValue.Call(inValues)
-	errorValue := reflect.Value{}
-
-	// Read optional factory error value.
-	if factory.outError {
-		errorValue = outValues[len(outValues)-1]
-		outValues = outValues[0 : len(outValues)-1]
-	}
 
 	// Handle factory output error if present.
-	if factory.outError && !errorValue.IsNil() {
-		err, _ := errorValue.Interface().(error)
+	if len(outValues) == 2 && !outValues[1].IsNil() {
+		err, _ := outValues[1].Interface().(error)
 		return fmt.Errorf("%w: %w", ErrFactoryReturnedError, err)
 	}
 
@@ -382,7 +355,7 @@ func (r *registry) spawnFactory(factory *factory) error {
 	factory.setSpawned(true)
 
 	// Save the factory out values.
-	factory.setOutValues(outValues)
+	factory.setOutValue(outValues[0])
 
 	// Save the factory spawn order.
 	r.mutex.Lock()
@@ -390,11 +363,6 @@ func (r *registry) spawnFactory(factory *factory) error {
 	r.mutex.Unlock()
 
 	return nil
-}
-
-// isNonEmptyInterface returns true when argument is an interface with methods.
-func isNonEmptyInterface(typ reflect.Type) bool {
-	return typ.Kind() == reflect.Interface && typ.NumMethod() > 0
 }
 
 // isEmptyInterface returns true when argument is an `any` interface.
@@ -408,8 +376,11 @@ func isContextInterface(typ reflect.Type) bool {
 	return typ.Kind() == reflect.Interface && typ.Implements(ctxType)
 }
 
-// errorType contains reflection type for error variable.
-var errorType = reflect.TypeOf((*error)(nil)).Elem()
+// isErrorInterface returns true when argument is an error interface.
+func isErrorInterface(typ reflect.Type) bool {
+	errType := reflect.TypeOf((*error)(nil)).Elem()
+	return typ.Kind() == reflect.Interface && typ.Implements(errType)
+}
 
 // getStackDepth returns current stack depth.
 func getStackDepth() int {

--- a/registry_test.go
+++ b/registry_test.go
@@ -30,8 +30,8 @@ import (
 
 // TestRegistryRegisterFactory tests corresponding registry method.
 func TestRegistryRegisterFactory(t *testing.T) {
-	fun := func(a, b, c string) (int, bool, error) {
-		return 1, true, nil
+	fun := func(a, b, c string) (int, error) {
+		return 1, nil
 	}
 
 	opts := WithMetadata("test", func() {})
@@ -66,8 +66,8 @@ func TestRegistryValidateFactories(t *testing.T) {
 		{
 			name: "ServiceNotResolvedError",
 			factories: []*Factory{
-				NewFactory(func(bool) error { return nil }),
-				NewFactory(func(string) error { return nil }),
+				NewFactory(func(bool) (int, error) { return 0, nil }),
+				NewFactory(func(string) (int32, error) { return 0, nil }),
 			},
 			wantErr: func(t *testing.T, err error) {
 				equal(t, errors.Is(err, ErrServiceNotResolved), true)
@@ -79,12 +79,12 @@ func TestRegistryValidateFactories(t *testing.T) {
 
 				equal(t, errors.Is(errs[0], ErrServiceNotResolved), true)
 				equal(t, errs[0].Error(), "failed to validate argument 'bool' (index 0) "+
-					"of factory 'Factory[func(bool) error]' from 'github.com/NVIDIA/gontainer': "+
+					"of factory 'Factory[func(bool) (int, error)]' from 'github.com/NVIDIA/gontainer': "+
 					"service not resolved")
 
 				equal(t, errors.Is(errs[1], ErrServiceNotResolved), true)
 				equal(t, errs[1].Error(), "failed to validate argument 'string' (index 0) "+
-					"of factory 'Factory[func(string) error]' from 'github.com/NVIDIA/gontainer': "+
+					"of factory 'Factory[func(string) (int32, error)]' from 'github.com/NVIDIA/gontainer': "+
 					"service not resolved")
 			},
 		},
@@ -103,12 +103,12 @@ func TestRegistryValidateFactories(t *testing.T) {
 				equal(t, len(errs), 2)
 
 				equal(t, errors.Is(errs[0], ErrServiceDuplicated), true)
-				equal(t, errs[0].Error(), "failed to validate output 'string' (index 0) "+
+				equal(t, errs[0].Error(), "failed to validate output 'string' "+
 					"of factory 'Factory[func() (string, error)]' from 'github.com/NVIDIA/gontainer': "+
 					"service duplicated")
 
 				equal(t, errors.Is(errs[1], ErrServiceDuplicated), true)
-				equal(t, errs[1].Error(), "failed to validate output 'string' (index 0) "+
+				equal(t, errs[1].Error(), "failed to validate output 'string' "+
 					"of factory 'Factory[func() (string, error)]' from 'github.com/NVIDIA/gontainer': "+
 					"service duplicated")
 			},
@@ -147,7 +147,8 @@ func TestRegistryValidateFactories(t *testing.T) {
 				NewFactory(func(struct{ X int }) string { return "s1" }),                   // not resolved, duplicate
 				NewFactory(func(ctx context.Context) (string, error) { return "s2", nil }), // duplicate
 				NewFactory(func(bool) (int, error) { return 1, nil }),                      // cycle
-				NewFactory(func(int) (bool, string) { return true, "s3" }),                 // cycle, duplicate
+				NewFactory(func(int) (bool, error) { return true, nil }),                   // cycle
+				NewFactory(func() string { return "s3" }),                                  // duplicate
 			},
 			wantErr: func(t *testing.T, err error) {
 				equal(t, errors.Is(err, ErrServiceNotResolved), true)
@@ -165,18 +166,18 @@ func TestRegistryValidateFactories(t *testing.T) {
 					"service not resolved")
 
 				equal(t, errors.Is(errs[1], ErrServiceDuplicated), true)
-				equal(t, errs[1].Error(), "failed to validate output 'string' (index 0) "+
+				equal(t, errs[1].Error(), "failed to validate output 'string' "+
 					"of factory 'Factory[func(struct { X int }) string]' from 'github.com/NVIDIA/gontainer': "+
 					"service duplicated")
 
 				equal(t, errors.Is(errs[2], ErrServiceDuplicated), true)
-				equal(t, errs[2].Error(), "failed to validate output 'string' (index 0) "+
+				equal(t, errs[2].Error(), "failed to validate output 'string' "+
 					"of factory 'Factory[func(context.Context) (string, error)]' from 'github.com/NVIDIA/gontainer': "+
 					"service duplicated")
 
 				equal(t, errors.Is(errs[3], ErrServiceDuplicated), true)
-				equal(t, errs[3].Error(), "failed to validate output 'string' (index 1) "+
-					"of factory 'Factory[func(int) (bool, string)]' from 'github.com/NVIDIA/gontainer': "+
+				equal(t, errs[3].Error(), "failed to validate output 'string' "+
+					"of factory 'Factory[func() string]' from 'github.com/NVIDIA/gontainer': "+
 					"service duplicated")
 
 				equal(t, errors.Is(errs[4], ErrCircularDependency), true)
@@ -184,7 +185,7 @@ func TestRegistryValidateFactories(t *testing.T) {
 					"from 'github.com/NVIDIA/gontainer': circular dependency")
 
 				equal(t, errors.Is(errs[5], ErrCircularDependency), true)
-				equal(t, errs[5].Error(), "failed to validate factory 'Factory[func(int) (bool, string)]' "+
+				equal(t, errs[5].Error(), "failed to validate factory 'Factory[func(int) (bool, error)]' "+
 					"from 'github.com/NVIDIA/gontainer': circular dependency")
 			},
 		},
@@ -217,7 +218,7 @@ func TestRegistrySpawnFactories(t *testing.T) {
 	err = registry.spawnFactories()
 	equal(t, err, nil)
 	equal(t, factory.spawned, true)
-	equal(t, factory.outValues[0].Interface(), true)
+	equal(t, factory.outValue.Interface(), true)
 }
 
 // TestRegistryResolveParallel tests corresponding registry method.
@@ -274,12 +275,13 @@ func TestRegistryResolveFuncServices(t *testing.T) {
 			fn1 func() int,
 			fn2 func(string) string,
 			fn3 func(string) string,
-		) {
+		) bool {
 			fact3Calls.Add(1)
 			equal(t, fn1(), 42)
 			equal(t, fn2("hello"), "hello test")
 			equal(t, fn3("world"), "world test")
 			equal(t, fn3("universe"), "universe test")
+			return true
 		}),
 	}
 
@@ -322,21 +324,6 @@ func TestRegistrySpawnWithErrors(t *testing.T) {
 		`factory returned error: failed to create new service`)
 }
 
-// TestIsNonEmptyInterface tests checking of argument to be non-empty interface.
-func TestIsNonEmptyInterface(t *testing.T) {
-	var t1 any
-	var t2 interface{}
-	var t3 struct{}
-	var t4 string
-	var t5 interface{ Close() error }
-
-	equal(t, isNonEmptyInterface(reflect.TypeOf(&t1).Elem()), false)
-	equal(t, isNonEmptyInterface(reflect.TypeOf(&t2).Elem()), false)
-	equal(t, isNonEmptyInterface(reflect.TypeOf(&t3).Elem()), false)
-	equal(t, isNonEmptyInterface(reflect.TypeOf(&t4).Elem()), false)
-	equal(t, isNonEmptyInterface(reflect.TypeOf(&t5).Elem()), true)
-}
-
 // TestIsEmptyInterface tests checking of argument to be empty interface.
 func TestIsEmptyInterface(t *testing.T) {
 	var t1 any
@@ -365,4 +352,19 @@ func TestIsContextInterface(t *testing.T) {
 	equal(t, isContextInterface(reflect.TypeOf(&t3).Elem()), false)
 	equal(t, isContextInterface(reflect.TypeOf(&t4).Elem()), false)
 	equal(t, isContextInterface(reflect.TypeOf(&t5).Elem()), true)
+}
+
+// TestIsErrorInterface tests checking of argument to be error.
+func TestIsErrorInterface(t *testing.T) {
+	var t1 any
+	var t2 interface{}
+	var t3 struct{}
+	var t4 string
+	var t5 error
+
+	equal(t, isErrorInterface(reflect.TypeOf(&t1).Elem()), false)
+	equal(t, isErrorInterface(reflect.TypeOf(&t2).Elem()), false)
+	equal(t, isErrorInterface(reflect.TypeOf(&t3).Elem()), false)
+	equal(t, isErrorInterface(reflect.TypeOf(&t4).Elem()), false)
+	equal(t, isErrorInterface(reflect.TypeOf(&t5).Elem()), true)
 }

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -22,19 +22,24 @@ import (
 	"testing"
 )
 
-// TestResolverService tests resolver service.
+// TestResolverService tests resolver service resolve.
 func TestResolverService(t *testing.T) {
+	svc1 := float64(100500)
+	svc2 := float32(100501)
+
 	container, err := New(
 		context.Background(),
-		NewFactory(func() string { return "string" }),
-		NewFactory(func(resolver *Resolver) {
-			var depExists string
+		NewService(svc1),
+		NewService(svc2),
+		NewFactory(func(resolver *Resolver) bool {
+			var depExists float64
 			equal(t, resolver.Resolve(&depExists), nil)
-			equal(t, depExists, "string")
+			equal(t, depExists, svc1)
 
 			var depNotExists int
 			equal(t, resolver.Resolve(&depNotExists) != nil, true)
 			equal(t, depNotExists, 0)
+			return true
 		}),
 	)
 	equal(t, err, nil)


### PR DESCRIPTION
This pull request refactors the service factory mechanism in the dependency injection container to enforce stricter rules: factories must now return exactly one service instance, optionally followed by an error, and multiple-output factories are no longer supported. The changes simplify factory signature validation, update related tests, and streamline the internal handling of factory outputs.

### Service Factory Signature Enforcement

* Updated documentation and code to require that a service factory returns a single service instance, optionally with an error; multiple service outputs are now explicitly rejected. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L139-R153) [[2]](diffhunk://#diff-8ae5e92a2a10b4779f44d65dcd9448ae0e189ba6cfa8680209deca1ce9f98d0aL32-R32)
* Factory signature validation logic refactored to enforce the new rule, with improved error messages for invalid signatures. [[1]](diffhunk://#diff-8ae5e92a2a10b4779f44d65dcd9448ae0e189ba6cfa8680209deca1ce9f98d0aL107-R90) [[2]](diffhunk://#diff-8ae5e92a2a10b4779f44d65dcd9448ae0e189ba6cfa8680209deca1ce9f98d0aL125-R115)

### Internal Factory Representation

* Refactored the internal `factory` struct and related methods to handle only a single output value and type, removing support for multiple outputs. [[1]](diffhunk://#diff-8ae5e92a2a10b4779f44d65dcd9448ae0e189ba6cfa8680209deca1ce9f98d0aL148-R130) [[2]](diffhunk://#diff-8ae5e92a2a10b4779f44d65dcd9448ae0e189ba6cfa8680209deca1ce9f98d0aL288-R273) [[3]](diffhunk://#diff-8ae5e92a2a10b4779f44d65dcd9448ae0e189ba6cfa8680209deca1ce9f98d0aL312-R301)
* Registry logic updated to work with single-output factories, including validation, resolution, and closing of services. [[1]](diffhunk://#diff-638576cf5913c90c8eb77dadc04e6834ec3061ae4873d3ed7eeca0a2908a1c63L82-L97) [[2]](diffhunk://#diff-638576cf5913c90c8eb77dadc04e6834ec3061ae4873d3ed7eeca0a2908a1c63L181-R184) [[3]](diffhunk://#diff-638576cf5913c90c8eb77dadc04e6834ec3061ae4873d3ed7eeca0a2908a1c63L281-R311)

### Test Updates

* Test cases updated to reflect the new factory signature requirements, removing examples of multi-output factories and adjusting assertions accordingly. [[1]](diffhunk://#diff-b1eb9afa48ad78a73fcc18342b9da970021b71d1eb6cf6e391a80012a31cbfd3L28-R29) [[2]](diffhunk://#diff-b1eb9afa48ad78a73fcc18342b9da970021b71d1eb6cf6e391a80012a31cbfd3R38-R48) [[3]](diffhunk://#diff-b1eb9afa48ad78a73fcc18342b9da970021b71d1eb6cf6e391a80012a31cbfd3L62-R62) [[4]](diffhunk://#diff-b1eb9afa48ad78a73fcc18342b9da970021b71d1eb6cf6e391a80012a31cbfd3L75-L91) [[5]](diffhunk://#diff-8046b034a1ad68ce96705decc695bb0b827a75d9817c7043d5c51c41c4f12933L27-R40) [[6]](diffhunk://#diff-edb24508617964ec78bbd08114140588702e64b9d1f8fce9540cf3162f0c38f3L33-R34) [[7]](diffhunk://#diff-edb24508617964ec78bbd08114140588702e64b9d1f8fce9540cf3162f0c38f3L69-R70)

### Utility and Validation Improvements

* Added `isErrorInterface` utility for improved error type detection in factory signature validation.
* Simplified and clarified registry error messages and validation logic. [[1]](diffhunk://#diff-8ae5e92a2a10b4779f44d65dcd9448ae0e189ba6cfa8680209deca1ce9f98d0aL107-R90) [[2]](diffhunk://#diff-638576cf5913c90c8eb77dadc04e6834ec3061ae4873d3ed7eeca0a2908a1c63L69-R69) [[3]](diffhunk://#diff-638576cf5913c90c8eb77dadc04e6834ec3061ae4873d3ed7eeca0a2908a1c63L126-R119)

These changes make the service container's behavior more predictable and easier to reason about, while reducing complexity in both the implementation and usage.