### PR TITLE
V2 devel: pass context to factories

### DIFF
--- a/container.go
+++ b/container.go
@@ -58,14 +58,14 @@ func New(ctx context.Context, factories ...*Factory) (result *Container, err err
 	}
 
 	// Register service resolver instance in the registry.
-	if factory, err := NewService(resolver).factory(); err != nil {
+	if factory, err := NewService(resolver).factory(ctx); err != nil {
 		return nil, fmt.Errorf("failed to register service resolver: %w", err)
 	} else {
 		registry.registerFactory(factory)
 	}
 
 	// Register function invoker instance in the registry.
-	if factory, err := NewService(invoker).factory(); err != nil {
+	if factory, err := NewService(invoker).factory(ctx); err != nil {
 		return nil, fmt.Errorf("failed to register function invoker: %w", err)
 	} else {
 		registry.registerFactory(factory)
@@ -73,7 +73,7 @@ func New(ctx context.Context, factories ...*Factory) (result *Container, err err
 
 	// Register provided factories in the registry.
 	for _, source := range factories {
-		if factory, err := source.factory(); err != nil {
+		if factory, err := source.factory(ctx); err != nil {
 			return nil, fmt.Errorf("failed to register factory: %w", err)
 		} else {
 			registry.registerFactory(factory)

--- a/factory.go
+++ b/factory.go
@@ -77,7 +77,7 @@ func (f *Factory) Metadata() FactoryMetadata {
 // factory produces internal representation for the factory.
 // Separate internal representation is used to let single
 // factory instance be used in multiple containers.
-func (f *Factory) factory() (*factory, error) {
+func (f *Factory) factory(ctx context.Context) (*factory, error) {
 	// Check factory configured.
 	if f.fn == nil {
 		return nil, errors.New("func is nil")
@@ -116,7 +116,7 @@ func (f *Factory) factory() (*factory, error) {
 	}
 
 	// Prepare cancellable context for the factory services.
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 
 	// Prepare registry factory instance.
 	return &factory{

--- a/factory_test.go
+++ b/factory_test.go
@@ -18,6 +18,7 @@
 package gontainer
 
 import (
+	"context"
 	"fmt"
 	"testing"
 )
@@ -28,8 +29,9 @@ func TestFactoryLoad(t *testing.T) {
 		return 100500, nil
 	}
 
+	ctx := context.Background()
 	factory := NewFactory(fun)
-	state, err := factory.factory()
+	state, err := factory.factory(ctx)
 
 	equal(t, err, nil)
 	equal(t, state.funcType.String(), "func(string, string, string) (int, error)")

--- a/registry_test.go
+++ b/registry_test.go
@@ -34,9 +34,10 @@ func TestRegistryRegisterFactory(t *testing.T) {
 		return 1, nil
 	}
 
+	ctx := context.Background()
 	opts := WithMetadata("test", func() {})
 	source := NewFactory(fun, opts)
-	factory, err := source.factory()
+	factory, err := source.factory(ctx)
 	equal(t, err, nil)
 
 	registry := &registry{}
@@ -192,9 +193,10 @@ func TestRegistryValidateFactories(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
 			registry := &registry{}
 			for _, source := range tt.factories {
-				factory, err := source.factory()
+				factory, err := source.factory(ctx)
 				equal(t, err, nil)
 				equal(t, factory == nil, false)
 				registry.registerFactory(factory)
@@ -208,7 +210,8 @@ func TestRegistryValidateFactories(t *testing.T) {
 func TestRegistrySpawnFactories(t *testing.T) {
 	source := NewFactory(func() bool { return true })
 
-	factory, err := source.factory()
+	ctx := context.Background()
+	factory, err := source.factory(ctx)
 	equal(t, err, nil)
 	equal(t, factory == nil, false)
 
@@ -229,7 +232,8 @@ func TestRegistryResolveParallel(t *testing.T) {
 		return true
 	})
 
-	factory, err := source.factory()
+	ctx := context.Background()
+	factory, err := source.factory(ctx)
 	equal(t, err, nil)
 	equal(t, factory == nil, false)
 
@@ -285,9 +289,10 @@ func TestRegistryResolveFuncServices(t *testing.T) {
 		}),
 	}
 
+	ctx := context.Background()
 	registry := &registry{}
 	for _, source := range sources {
-		factory, err := source.factory()
+		factory, err := source.factory(ctx)
 		equal(t, err, nil)
 		equal(t, factory == nil, false)
 		registry.registerFactory(factory)
@@ -310,7 +315,8 @@ func TestRegistrySpawnWithErrors(t *testing.T) {
 		return false, errors.New("failed to create new service")
 	})
 
-	factory, err := source.factory()
+	ctx := context.Background()
+	factory, err := source.factory(ctx)
 	equal(t, err, nil)
 	equal(t, factory == nil, false)
 


### PR DESCRIPTION
This pull request refactors the factory creation process to require an explicit `context.Context` parameter, improving context propagation and lifecycle management for services. The change affects both the implementation and all relevant test cases, ensuring that context is properly passed and utilized throughout the codebase.

**Factory context propagation improvements:**

* Changed the signature of the `Factory.factory` method to accept a `context.Context` parameter, replacing the previous use of a background context and enabling better context control. (`factory.go`, [factory.goL80-R80](diffhunk://#diff-8ae5e92a2a10b4779f44d65dcd9448ae0e189ba6cfa8680209deca1ce9f98d0aL80-R80))
* Updated the internal context creation in `Factory.factory` to use `context.WithoutCancel(ctx)` instead of `context.Background()`, preserving cancellation and value propagation from the provided context. (`factory.go`, [factory.goL119-R119](diffhunk://#diff-8ae5e92a2a10b4779f44d65dcd9448ae0e189ba6cfa8680209deca1ce9f98d0aL119-R119))

**Container and service registration updates:**

* Modified the `New` function in `container.go` to pass the context to all factory registrations, ensuring consistent context usage when registering service resolver, function invoker, and other factories. (`container.go`, [container.goL61-R76](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL61-R76))

**Test suite adjustments:**

* Updated all test cases in `factory_test.go` and `registry_test.go` to provide a context when calling the `factory` method, aligning tests with the new method signature and context requirements. (`factory_test.go`, [[1]](diffhunk://#diff-8046b034a1ad68ce96705decc695bb0b827a75d9817c7043d5c51c41c4f12933R21) [[2]](diffhunk://#diff-8046b034a1ad68ce96705decc695bb0b827a75d9817c7043d5c51c41c4f12933R32-R34); `registry_test.go`, [[3]](diffhunk://#diff-edb24508617964ec78bbd08114140588702e64b9d1f8fce9540cf3162f0c38f3R37-R40) [[4]](diffhunk://#diff-edb24508617964ec78bbd08114140588702e64b9d1f8fce9540cf3162f0c38f3R196-R199) [[5]](diffhunk://#diff-edb24508617964ec78bbd08114140588702e64b9d1f8fce9540cf3162f0c38f3L211-R214) [[6]](diffhunk://#diff-edb24508617964ec78bbd08114140588702e64b9d1f8fce9540cf3162f0c38f3L232-R236) [[7]](diffhunk://#diff-edb24508617964ec78bbd08114140588702e64b9d1f8fce9540cf3162f0c38f3R292-R295) [[8]](diffhunk://#diff-edb24508617964ec78bbd08114140588702e64b9d1f8fce9540cf3162f0c38f3L313-R319)