### PR TITLE
V2 devel: remove factory metadata support

### DIFF
--- a/factory.go
+++ b/factory.go
@@ -32,16 +32,10 @@ import (
 // must return exactly one service, optionally followed by an error.
 type FactoryFunc any
 
-// FactoryMetadata defines a key-value store for attaching metadata to a factory.
-//
-// Metadata can be used for annotations, tagging, grouping, versioning, or
-// integration with external tools. It is populated using `WithMetadata()` option.
-type FactoryMetadata map[string]any
-
 // Factory declares a service factory definition used by the container to construct services.
 //
-// A Factory wraps a factory function along with its metadata, input/output type information,
-// and internal state used during service resolution and lifecycle management.
+// A Factory wraps a factory function along with its input/output type information and internal
+// state used during service resolution and lifecycle management.
 //
 // It is created using NewFactory or NewService, and typically registered into the container
 // to enable dependency injection and lifecycle control.
@@ -54,9 +48,6 @@ type Factory struct {
 
 	// Factory function location.
 	source string
-
-	// Factory metadata.
-	metadata FactoryMetadata
 }
 
 // Name returns factory function name.
@@ -67,11 +58,6 @@ func (f *Factory) Name() string {
 // Source returns factory function source.
 func (f *Factory) Source() string {
 	return f.source
-}
-
-// Metadata returns associated factory metadata.
-func (f *Factory) Metadata() FactoryMetadata {
-	return f.metadata
 }
 
 // factory produces internal representation for the factory.
@@ -141,12 +127,6 @@ func (f *Factory) factory(ctx context.Context) (*factory, error) {
 	}, nil
 }
 
-// FactoryOpt defines a functional option for configuring a service factory.
-//
-// Factory options allow customizing the behavior or metadata of a factory
-// at the time of its creation, using functions like WithMetadata, WithTag, etc.
-type FactoryOpt func(*Factory)
-
 // NewService creates a new service factory that always returns the given singleton value.
 //
 // This is a convenience helper for registering preconstructed service instances
@@ -158,16 +138,12 @@ type FactoryOpt func(*Factory)
 //
 //	logger := NewLogger()
 //	gontainer.NewService(logger)
-func NewService[T any](singleton T, opts ...FactoryOpt) *Factory {
+func NewService[T any](singleton T) *Factory {
 	dataType := reflect.TypeOf(&singleton).Elem()
 	factory := &Factory{
-		fn:       func() T { return singleton },
-		name:     fmt.Sprintf("Service[%s]", dataType),
-		source:   dataType.PkgPath(),
-		metadata: FactoryMetadata{},
-	}
-	for _, opt := range opts {
-		opt(factory)
+		fn:     func() T { return singleton },
+		name:   fmt.Sprintf("Service[%s]", dataType),
+		source: dataType.PkgPath(),
 	}
 	return factory
 }
@@ -177,40 +153,19 @@ func NewService[T any](singleton T, opts ...FactoryOpt) *Factory {
 // The factory function must be a valid function. It may accept dependencies as input parameters,
 // and return one or more service instances, optionally followed by an error as the last return value.
 //
-// Optional configuration can be applied via factory options (`FactoryOpt`), such as providing additional metadata.
-//
 // The resulting Factory can be registered in the container.
 //
 // Example:
 //
 //	gontainer.NewFactory(func(db *Database) (*Handler, error), gontainer.WithTag("http"))
-func NewFactory(factoryFn FactoryFunc, opts ...FactoryOpt) *Factory {
+func NewFactory(factoryFn FactoryFunc) *Factory {
 	funcValue := reflect.ValueOf(factoryFn)
 	factory := &Factory{
-		fn:       factoryFn,
-		name:     fmt.Sprintf("Factory[%s]", funcValue.Type()),
-		source:   getFuncSource(funcValue),
-		metadata: FactoryMetadata{},
-	}
-	for _, opt := range opts {
-		opt(factory)
+		fn:     factoryFn,
+		name:   fmt.Sprintf("Factory[%s]", funcValue.Type()),
+		source: getFuncSource(funcValue),
 	}
 	return factory
-}
-
-// WithMetadata adds a custom metadata key-value pair to the factory.
-//
-// Metadata can be used to attach arbitrary information to a factory,
-// such as labels, tags, annotations, or integration-specific flags.
-// This data is accessible through the factory’s metadata map at runtime.
-//
-// Example:
-//
-//	gontainer.NewFactory(..., gontainer.WithMetadata("version", "v1.2"))
-func WithMetadata(key string, value any) FactoryOpt {
-	return func(factory *Factory) {
-		factory.metadata[key] = value
-	}
 }
 
 // getFuncSource returns func source path.

--- a/factory.go
+++ b/factory.go
@@ -27,11 +27,6 @@ import (
 	"sync"
 )
 
-// FactoryFunc declares the type for a service factory function.
-// A factory function may accept dependencies as input parameters and
-// must return exactly one service, optionally followed by an error.
-type FactoryFunc any
-
 // Factory declares a service factory definition used by the container to construct services.
 //
 // A Factory wraps a factory function along with its input/output type information and internal
@@ -41,7 +36,7 @@ type FactoryFunc any
 // to enable dependency injection and lifecycle control.
 type Factory struct {
 	// Factory function.
-	fn FactoryFunc
+	fn any
 
 	// Factory function name.
 	name string
@@ -138,10 +133,10 @@ func (f *Factory) factory(ctx context.Context) (*factory, error) {
 //
 //	logger := NewLogger()
 //	gontainer.NewService(logger)
-func NewService[T any](singleton T) *Factory {
-	dataType := reflect.TypeOf(&singleton).Elem()
+func NewService[T any](service T) *Factory {
+	dataType := reflect.TypeOf(&service).Elem()
 	factory := &Factory{
-		fn:     func() T { return singleton },
+		fn:     func() T { return service },
 		name:   fmt.Sprintf("Service[%s]", dataType),
 		source: dataType.PkgPath(),
 	}
@@ -158,10 +153,10 @@ func NewService[T any](singleton T) *Factory {
 // Example:
 //
 //	gontainer.NewFactory(func(db *Database) (*Handler, error), gontainer.WithTag("http"))
-func NewFactory(factoryFn FactoryFunc) *Factory {
-	funcValue := reflect.ValueOf(factoryFn)
+func NewFactory(function any) *Factory {
+	funcValue := reflect.ValueOf(function)
 	factory := &Factory{
-		fn:     factoryFn,
+		fn:     function,
 		name:   fmt.Sprintf("Factory[%s]", funcValue.Type()),
 		source: getFuncSource(funcValue),
 	}

--- a/factory_test.go
+++ b/factory_test.go
@@ -95,23 +95,6 @@ func TestFactoryInfo(t *testing.T) {
 	}
 }
 
-// TestFactoryMetadata tests factory metadata attachment.
-func TestFactoryMetadata(t *testing.T) {
-	fun := func(a, b, c string) (int, bool, error) {
-		return 1, true, nil
-	}
-
-	var opts []FactoryOpt
-	opts = append(opts, WithMetadata("key1", "value1"))
-	opts = append(opts, WithMetadata("key2", 123456))
-	factory := NewFactory(fun, opts...)
-
-	equal(t, factory.Metadata(), FactoryMetadata{
-		"key1": "value1",
-		"key2": 123456,
-	})
-}
-
 type globalType struct{}
 
 func globalFunc(string) {}

--- a/registry.go
+++ b/registry.go
@@ -26,7 +26,7 @@ import (
 	"sync"
 )
 
-// registry contains all defined factories metadata.
+// registry contains all defined factories.
 type registry struct {
 	factories []*factory
 	sequence  []*factory

--- a/registry_test.go
+++ b/registry_test.go
@@ -35,8 +35,7 @@ func TestRegistryRegisterFactory(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	opts := WithMetadata("test", func() {})
-	source := NewFactory(fun, opts)
+	source := NewFactory(fun)
 	factory, err := source.factory(ctx)
 	equal(t, err, nil)
 


### PR DESCRIPTION
This pull request removes support for attaching metadata to service factories in the dependency injection container. The metadata-related types, options, and methods have been deleted from both the implementation and the test suite. The `Factory` struct and its creation methods have been simplified as a result.

Removed metadata support:

* Deleted the `FactoryMetadata` type, the `metadata` field from the `Factory` struct, and the `Metadata()` method, eliminating all metadata handling from factories (`factory.go`, [[1]](diffhunk://#diff-8ae5e92a2a10b4779f44d65dcd9448ae0e189ba6cfa8680209deca1ce9f98d0aL30-L59) [[2]](diffhunk://#diff-8ae5e92a2a10b4779f44d65dcd9448ae0e189ba6cfa8680209deca1ce9f98d0aL72-L76).
* Removed the `FactoryOpt` type and all related code for functional options, including `WithMetadata` and option handling in `NewFactory` and `NewService` (`factory.go`, [[1]](diffhunk://#diff-8ae5e92a2a10b4779f44d65dcd9448ae0e189ba6cfa8680209deca1ce9f98d0aL144-L149) [[2]](diffhunk://#diff-8ae5e92a2a10b4779f44d65dcd9448ae0e189ba6cfa8680209deca1ce9f98d0aL161-L170) [[3]](diffhunk://#diff-8ae5e92a2a10b4779f44d65dcd9448ae0e189ba6cfa8680209deca1ce9f98d0aL180-L215).

Simplified factory creation:

* Updated `NewFactory` and `NewService` to no longer accept options or handle metadata, streamlining their signatures and usage (`factory.go`, [[1]](diffhunk://#diff-8ae5e92a2a10b4779f44d65dcd9448ae0e189ba6cfa8680209deca1ce9f98d0aL161-L170) [[2]](diffhunk://#diff-8ae5e92a2a10b4779f44d65dcd9448ae0e189ba6cfa8680209deca1ce9f98d0aL180-L215).

Test suite cleanup:

* Removed all tests for factory metadata, including `TestFactoryMetadata`, and updated registry tests to use the simplified factory creation (`factory_test.go`, [[1]](diffhunk://#diff-8046b034a1ad68ce96705decc695bb0b827a75d9817c7043d5c51c41c4f12933L98-L114); `registry_test.go`, [[2]](diffhunk://#diff-edb24508617964ec78bbd08114140588702e64b9d1f8fce9540cf3162f0c38f3L38-R38).

Documentation updates:

* Revised comments throughout the codebase to reflect the removal of metadata and options from factories and the registry (`factory.go`, [[1]](diffhunk://#diff-8ae5e92a2a10b4779f44d65dcd9448ae0e189ba6cfa8680209deca1ce9f98d0aL30-L59); `registry.go`, [[2]](diffhunk://#diff-638576cf5913c90c8eb77dadc04e6834ec3061ae4873d3ed7eeca0a2908a1c63L29-R29).