### PR TITLE
V2 devel: switch to container options from the factory type

### DIFF
--- a/container.go
+++ b/container.go
@@ -24,7 +24,7 @@ import (
 )
 
 // Run runs a container with a set of configured factories.
-func Run(ctx context.Context, factories ...*Factory) error {
+func Run(ctx context.Context, options ...Option) error {
 	// Prepare container context ignoring the cancelling.
 	// When cancelled, it closes `container.Done()` channel
 	// and unblocks any waiting read from `container.Done()`.
@@ -41,25 +41,19 @@ func Run(ctx context.Context, factories ...*Factory) error {
 	invoker := &Invoker{resolver: resolver}
 
 	// Register service resolver instance in the registry.
-	if factory, err := NewService(resolver).factory(ctx); err != nil {
-		return fmt.Errorf("failed to register service resolver: %w", err)
-	} else {
-		registry.registerFactory(factory)
+	if err := NewService(resolver)(ctx, registry); err != nil {
+		return fmt.Errorf("failed to register resolver: %w", err)
 	}
 
 	// Register function invoker instance in the registry.
-	if factory, err := NewService(invoker).factory(ctx); err != nil {
-		return fmt.Errorf("failed to register function invoker: %w", err)
-	} else {
-		registry.registerFactory(factory)
+	if err := NewService(invoker)(ctx, registry); err != nil {
+		return fmt.Errorf("failed to register invoker: %w", err)
 	}
 
 	// Register provided factories in the registry.
-	for _, source := range factories {
-		if factory, err := source.factory(ctx); err != nil {
-			return fmt.Errorf("failed to register factory: %w", err)
-		} else {
-			registry.registerFactory(factory)
+	for _, option := range options {
+		if err := option(ctx, registry); err != nil {
+			return fmt.Errorf("failed to apply option: %w", err)
 		}
 	}
 
@@ -82,30 +76,87 @@ func Run(ctx context.Context, factories ...*Factory) error {
 	return nil
 }
 
-// NewFactory creates a new service factory using the provided factory function.
+// Option defines an option for the service container.
+type Option func(ctx context.Context, registry *registry) error
+
+// NewFactory creates a new service load using the provided load function.
 //
-// The factory function must be a valid function. It may accept dependencies as input parameters,
-// and return one or more service instances, optionally followed by an error as the last return value.
-//
-// The resulting Factory can be registered in the container.
+// The load function must be a function. It may accept dependencies as input parameters and return
+// exactly one service instances, optionally followed by an error as the second return value.
 //
 // Example:
 //
-//	gontainer.NewFactory(func(db *Database) (*Handler, error), gontainer.WithTag("http"))
-func NewFactory(function any) *Factory {
+//	gontainer.NewFactory(func(db *Database) (*Handler, error) { ... })
+//	gontainer.NewFactory(func(db *Database) *Handler { ... })
+func NewFactory(function any) Option {
 	funcValue := reflect.ValueOf(function)
-	factory := &Factory{
-		fn:     function,
-		name:   fmt.Sprintf("Factory[%s]", funcValue.Type()),
-		source: getFuncSource(funcValue),
+	funcType := reflect.TypeOf(function)
+
+	// Prepare factory description.
+	name := fmt.Sprintf("Factory[%s]", funcValue.Type())
+	source := getFuncSource(funcValue)
+
+	// Prepare option callback.
+	return func(ctx context.Context, registry *registry) error {
+		// Validate function type.
+		if funcType.Kind() != reflect.Func {
+			return fmt.Errorf("invalid type: %s", funcType)
+		}
+
+		// Prepare default value and error getters.
+		var getOutType getOutTypeFn
+		var getOutValue getOutValueFn
+		var getOutError getOutErrorFn
+
+		// Prepare value and error getters.
+		switch {
+		// Factory returns nothing.
+		case funcType.NumOut() == 0:
+			getOutType = func(outTypes []reflect.Type) reflect.Type { return nil }
+			getOutValue = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
+			getOutError = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
+
+		// Factory returns only error.
+		case funcType.NumOut() == 1 && isErrorInterface(funcType.Out(0)):
+			getOutType = func(outTypes []reflect.Type) reflect.Type { return nil }
+			getOutValue = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
+			getOutError = func(outValues []reflect.Value) reflect.Value { return outValues[0] }
+
+		// Factory returns exactly one service.
+		case funcType.NumOut() == 1 && !isEmptyInterface(funcType.Out(0)):
+			getOutType = func(outTypes []reflect.Type) reflect.Type { return outTypes[0] }
+			getOutValue = func(outValues []reflect.Value) reflect.Value { return outValues[0] }
+			getOutError = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
+
+		// Factory returns a service and an error.
+		case funcType.NumOut() == 2 && !isEmptyInterface(funcType.Out(0)) && isErrorInterface(funcType.Out(1)):
+			getOutType = func(outTypes []reflect.Type) reflect.Type { return outTypes[0] }
+			getOutValue = func(outValues []reflect.Value) reflect.Value { return outValues[0] }
+			getOutError = func(outValues []reflect.Value) reflect.Value { return outValues[1] }
+
+		// Factory signature is invalid.
+		default:
+			return fmt.Errorf("invalid signature: %s", funcType)
+		}
+
+		// Load the factory internal representation.
+		state, err := newFactory(ctx, name, source, funcValue, getOutType, getOutValue, getOutError)
+		if err != nil {
+			return fmt.Errorf("failed to load factory '%s': %w", name, err)
+		}
+
+		// Register factory in the registry.
+		registry.registerFactory(state)
+
+		// Factory registered.
+		return nil
 	}
-	return factory
 }
 
-// NewService creates a new service factory that always returns the given singleton value.
+// NewService creates a new service load that always returns the given singleton value.
 //
 // This is a convenience helper for registering preconstructed service instances
-// as factories. The returned factory produces the same instance on every invocation.
+// as factories. The returned load produces the same instance on every invocation.
 //
 // This is useful for registering constants, mocks, or externally constructed values.
 //
@@ -113,12 +164,35 @@ func NewFactory(function any) *Factory {
 //
 //	logger := NewLogger()
 //	gontainer.NewService(logger)
-func NewService[T any](service T) *Factory {
-	dataType := reflect.TypeOf(&service).Elem()
-	factory := &Factory{
-		fn:     func() T { return service },
-		name:   fmt.Sprintf("Service[%s]", dataType),
-		source: dataType.PkgPath(),
+func NewService[T any](service T) Option {
+	function := func() T { return service }
+	funcValue := reflect.ValueOf(function)
+	funcType := reflect.TypeOf(function)
+	serviceType := reflect.TypeOf(&service).Elem()
+
+	// Prepare factory description.
+	name := fmt.Sprintf("Service[%s]", serviceType)
+	source := serviceType.PkgPath()
+
+	// Prepare option callback.
+	return func(ctx context.Context, registry *registry) error {
+		// Prepare value and error getters.
+		getOutType := func(outTypes []reflect.Type) reflect.Type { return funcType.Out(0) }
+		getOutValue := func(outValues []reflect.Value) reflect.Value {
+			return outValues[0]
+		}
+		getOutError := func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
+
+		// Load the factory internal representation.
+		state, err := newFactory(ctx, name, source, funcValue, getOutType, getOutValue, getOutError)
+		if err != nil {
+			return fmt.Errorf("failed to load factory '%s': %w", name, err)
+		}
+
+		// Register factory in the registry.
+		registry.registerFactory(state)
+
+		// Factory registered.
+		return nil
 	}
-	return factory
 }

--- a/examples/03_complete_webapp/services/app/factory.go
+++ b/examples/03_complete_webapp/services/app/factory.go
@@ -27,7 +27,7 @@ import (
 )
 
 // WithAppEndpoints returns a factory which configures app endpoints.
-func WithAppEndpoints() *gontainer.Factory {
+func WithAppEndpoints() gontainer.Option {
 	return gontainer.NewFactory(
 		func(logger *slog.Logger, server *httpsvr.Server) {
 			logger = logger.With("service", "app")
@@ -43,7 +43,7 @@ func WithAppEndpoints() *gontainer.Factory {
 }
 
 // WithHealthEndpoints returns a factory which configures health check endpoints.
-func WithHealthEndpoints() *gontainer.Factory {
+func WithHealthEndpoints() gontainer.Option {
 	return gontainer.NewFactory(
 		func(logger *slog.Logger, server *httpsvr.Server) {
 			logger = logger.With("service", "app")
@@ -59,7 +59,7 @@ func WithHealthEndpoints() *gontainer.Factory {
 }
 
 // WithAppEntryPoint returns a factory which performs final app start and waits for termination.
-func WithAppEntryPoint(terminate <-chan os.Signal) *gontainer.Factory {
+func WithAppEntryPoint(terminate <-chan os.Signal) gontainer.Option {
 	return gontainer.NewFactory(
 		func(logger *slog.Logger, server *httpsvr.Server) error {
 			// Start serving requests.

--- a/examples/03_complete_webapp/services/config/factory.go
+++ b/examples/03_complete_webapp/services/config/factory.go
@@ -22,7 +22,7 @@ import (
 )
 
 // WithConfig returns a factory for the Config service.
-func WithConfig() *gontainer.Factory {
+func WithConfig() gontainer.Option {
 	return gontainer.NewFactory(func() *Config {
 		return NewConfig()
 	})

--- a/examples/03_complete_webapp/services/httpsvr/factory.go
+++ b/examples/03_complete_webapp/services/httpsvr/factory.go
@@ -79,7 +79,7 @@ func (s *Server) Close() error {
 }
 
 // WithHTTPServer returns a factory for the HTTP server service.
-func WithHTTPServer() *gontainer.Factory {
+func WithHTTPServer() gontainer.Option {
 	return gontainer.NewFactory(
 		func(logger *slog.Logger, confsvc *confmod.Config) (*Server, error) {
 			// Prepare HTTP server config.

--- a/examples/03_complete_webapp/services/logging/factory.go
+++ b/examples/03_complete_webapp/services/logging/factory.go
@@ -27,7 +27,7 @@ import (
 )
 
 // WithSlogLogger returns a factory for the slog logger.
-func WithSlogLogger() *gontainer.Factory {
+func WithSlogLogger() gontainer.Option {
 	return gontainer.NewFactory(
 		func(confsvc *confmod.Config) (*slog.Logger, error) {
 			// Prepare logger config.

--- a/factory.go
+++ b/factory.go
@@ -19,8 +19,6 @@ package gontainer
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"reflect"
 	"runtime"
 	"strings"
@@ -43,83 +41,6 @@ type Factory struct {
 
 	// Factory function location.
 	source string
-}
-
-// Name returns factory function name.
-func (f *Factory) Name() string {
-	return f.name
-}
-
-// Source returns factory function source.
-func (f *Factory) Source() string {
-	return f.source
-}
-
-// factory produces internal representation for the factory.
-// Separate internal representation is used to let single
-// factory instance be used in multiple containers.
-func (f *Factory) factory(ctx context.Context) (*factory, error) {
-	// Check factory configured.
-	if f.fn == nil {
-		return nil, errors.New("func is nil")
-	}
-
-	// Validate factory type and signature.
-	funcType := reflect.TypeOf(f.fn)
-	funcValue := reflect.ValueOf(f.fn)
-	if funcType.Kind() != reflect.Func {
-		return nil, fmt.Errorf("invalid type: %s", funcType)
-	}
-
-	// Index factory input types from the function signature.
-	inTypes := make([]reflect.Type, 0, funcType.NumIn())
-	for index := 0; index < funcType.NumIn(); index++ {
-		inTypes = append(inTypes, funcType.In(index))
-	}
-
-	// Index factory output types from the function signature.
-	outTypes := make([]reflect.Type, 0, funcType.NumOut())
-	for index := 0; index < funcType.NumOut(); index++ {
-		outTypes = append(outTypes, funcType.Out(index))
-	}
-
-	var outType reflect.Type
-
-	// Validate factory output types.
-	switch {
-	// Factory returns nothing.
-	case len(outTypes) == 0:
-
-	// Factory returns only error.
-	case len(outTypes) == 1 && isErrorInterface(outTypes[0]):
-
-	// Factory returns exactly one service.
-	case len(outTypes) == 1 && !isEmptyInterface(outTypes[0]):
-		outType = outTypes[0]
-
-	// Factory returns a service and an error.
-	case len(outTypes) == 2 && !isEmptyInterface(outTypes[0]) && isErrorInterface(outTypes[1]):
-		outType = outTypes[0]
-
-	// Factory has invalid out signature.
-	default:
-		return nil, fmt.Errorf("invalid signature: %s", funcType)
-	}
-
-	// Prepare cancellable context for the factory services.
-	ctx, cancel := context.WithCancel(context.WithoutCancel(ctx))
-
-	// Prepare registry factory instance.
-	return &factory{
-		source:    f,
-		spawned:   false,
-		ctx:       ctx,
-		cancel:    cancel,
-		funcType:  funcType,
-		funcValue: funcValue,
-		inTypes:   inTypes,
-		outType:   outType,
-	}, nil
 }
 
 // getFuncSource returns func source path.
@@ -159,25 +80,69 @@ func splitFuncName(funcFullName string) (string, string) {
 	return packageName, funcName
 }
 
+// newFactory loads factory function to the internal representation.
+func newFactory(
+	ctx context.Context, name, source string, funcValue reflect.Value,
+	getOutType getOutTypeFn, getOutValue getOutValueFn, getOutError getOutErrorFn,
+) (*factory, error) {
+	// Prepare function reflect type.
+	funcType := funcValue.Type()
+
+	// Index factory input types from the function signature.
+	inTypes := make([]reflect.Type, 0, funcType.NumIn())
+	for index := 0; index < funcType.NumIn(); index++ {
+		inTypes = append(inTypes, funcType.In(index))
+	}
+
+	// Index factory output types from the function signature.
+	outTypes := make([]reflect.Type, 0, funcType.NumOut())
+	for index := 0; index < funcType.NumOut(); index++ {
+		outTypes = append(outTypes, funcType.Out(index))
+	}
+
+	// Prepare cancellable context for the factory services.
+	ctx, cancel := context.WithCancel(context.WithoutCancel(ctx))
+
+	// Prepare registry factory instance.
+	return &factory{
+		ctx:       ctx,
+		cancel:    cancel,
+		name:      name,
+		source:    source,
+		funcType:  funcType,
+		funcValue: funcValue,
+		inTypes:   inTypes,
+		outTypes:  outTypes,
+
+		// Signature-dependent.
+		getOutTypeFn:  getOutType,
+		getOutValueFn: getOutValue,
+		getOutErrorFn: getOutError,
+	}, nil
+}
+
 // factory is the factory internal representation.
 type factory struct {
-	// Factory source.
-	source *Factory
-
-	// Factory spawn mutex.
-	spawnMu sync.Mutex
-
-	// Factory spawned mutex.
-	spawnedMu sync.RWMutex
-
-	// Factory is spawned.
-	spawned bool
-
 	// Factory context value.
 	ctx context.Context
 
 	// Factory context cancel.
 	cancel context.CancelFunc
+
+	// Factory func name.
+	name string
+
+	// Factory func source.
+	source string
+
+	// Factory spawn mutex.
+	spawnMu sync.Mutex
+
+	// Factory is spawned mutex.
+	isSpawnedMu sync.RWMutex
+
+	// Factory is spawned.
+	isSpawned bool
 
 	// Factory function type.
 	funcType reflect.Type
@@ -188,40 +153,99 @@ type factory struct {
 	// Factory input types.
 	inTypes []reflect.Type
 
-	// Factory output type.
-	outType reflect.Type
+	// Factory output types.
+	outTypes []reflect.Type
 
 	// Factory output mutex.
-	outValueMu sync.RWMutex
+	outValuesMu sync.RWMutex
 
-	// Factory output value.
-	outValue reflect.Value
+	// Factory output values.
+	outValues []reflect.Value
+
+	// Factory output type getter.
+	getOutTypeFn getOutTypeFn
+
+	// Factory output value getter.
+	getOutValueFn getOutValueFn
+
+	// Factory output error getter.
+	getOutErrorFn getOutErrorFn
 }
 
-// getSpawned returns factory spawned status in a thread-safe way.
-func (f *factory) getSpawned() bool {
-	f.spawnedMu.RLock()
-	defer f.spawnedMu.RUnlock()
-	return f.spawned
+// getIsSpawned returns factory spawned status in a thread-safe way.
+func (f *factory) getIsSpawned() bool {
+	f.isSpawnedMu.RLock()
+	defer f.isSpawnedMu.RUnlock()
+	return f.isSpawned
 }
 
-// setSpawned sets factory spawned status in a thread-safe way.
-func (f *factory) setSpawned(value bool) {
-	f.spawnedMu.Lock()
-	defer f.spawnedMu.Unlock()
-	f.spawned = value
+// setIsSpawned sets factory spawned status in a thread-safe way.
+func (f *factory) setIsSpawned(value bool) {
+	f.isSpawnedMu.Lock()
+	defer f.isSpawnedMu.Unlock()
+	f.isSpawned = value
+}
+
+// getOutValues returns factory output values in a thread-safe way.
+func (f *factory) getOutValues() []reflect.Value {
+	f.outValuesMu.RLock()
+	defer f.outValuesMu.RUnlock()
+	return f.outValues
+}
+
+// setOutValues sets factory output values in a thread-safe way.
+func (f *factory) setOutValues(values []reflect.Value) {
+	f.outValuesMu.Lock()
+	defer f.outValuesMu.Unlock()
+	f.outValues = values
+}
+
+// getOutType returns factory output type in a thread-safe way.
+func (f *factory) getOutType() reflect.Type {
+	return f.getOutTypeFn(f.outTypes)
 }
 
 // getOutValue returns factory output value in a thread-safe way.
 func (f *factory) getOutValue() reflect.Value {
-	f.outValueMu.RLock()
-	defer f.outValueMu.RUnlock()
-	return f.outValue
+	if !f.getIsSpawned() {
+		return reflect.Value{}
+	}
+
+	// Get the factory output value.
+	outValues := f.getOutValues()
+	return f.getOutValueFn(outValues)
 }
 
-// setOutValue sets factory output value in a thread-safe way.
-func (f *factory) setOutValue(value reflect.Value) {
-	f.outValueMu.Lock()
-	defer f.outValueMu.Unlock()
-	f.outValue = value
+// getOutError returns factory output error in a thread-safe way.
+func (f *factory) getOutError() error {
+	// Get the factory output value.
+	outValues := f.getOutValues()
+	outValue := f.getOutErrorFn(outValues)
+
+	// Check if the value is valid.
+	if !outValue.IsValid() {
+		return nil
+	}
+
+	// Check if the value is nil.
+	if outValue.IsNil() {
+		return nil
+	}
+
+	// Check if the value is an error.
+	if err, ok := outValue.Interface().(error); ok {
+		return err
+	}
+
+	// Return nil.
+	return nil
 }
+
+// getOutTypeFn is the function type for getting an output type.
+type getOutTypeFn func([]reflect.Type) reflect.Type
+
+// getOutValueFn is the function type for getting an output value.
+type getOutValueFn func([]reflect.Value) reflect.Value
+
+// getOutErrorFn is the function type for getting an output error.
+type getOutErrorFn func([]reflect.Value) reflect.Value

--- a/factory_test.go
+++ b/factory_test.go
@@ -20,6 +20,7 @@ package gontainer
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"testing"
 )
 
@@ -30,16 +31,19 @@ func TestFactoryLoad(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	factory := NewFactory(fun)
-	state, err := factory.factory(ctx)
+	option := NewFactory(fun)
+	registry := &registry{}
+	equal(t, option(ctx, registry), nil)
+	factory := registry.factories[0]
 
-	equal(t, err, nil)
-	equal(t, state.funcType.String(), "func(string, string, string) (int, error)")
-	equal(t, state.funcValue.String(), "<func(string, string, string) (int, error) Value>")
-	equal(t, fmt.Sprint(state.inTypes), "[string string string]")
-	equal(t, fmt.Sprint(state.outType), "int")
-	equal(t, state.spawned, false)
-	equal(t, state.outValue.IsValid(), false)
+	equal(t, factory.funcType.String(), "func(string, string, string) (int, error)")
+	equal(t, factory.funcValue.String(), "<func(string, string, string) (int, error) Value>")
+	equal(t, fmt.Sprint(factory.inTypes), "[string string string]")
+	equal(t, fmt.Sprint(factory.outTypes), "[int error]")
+	equal(t, fmt.Sprint(factory.getOutType()), "int")
+	equal(t, factory.isSpawned, false)
+	equal(t, factory.outValues, []reflect.Value(nil))
+	equal(t, factory.getOutValue().IsValid(), false)
 }
 
 // TestFactoryInfo tests factories info.
@@ -52,7 +56,7 @@ func TestFactoryInfo(t *testing.T) {
 
 	tests := []struct {
 		name  string
-		arg1  *Factory
+		arg1  Option
 		want1 string
 		want2 string
 	}{
@@ -83,14 +87,13 @@ func TestFactoryInfo(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got1 := tt.arg1.Name()
-			if got1 != tt.want1 {
-				t.Errorf("Factory.Name() got = %v, want %v", got1, tt.want1)
-			}
-			got2 := tt.arg1.Source()
-			if got2 != tt.want2 {
-				t.Errorf("Factory.Source() got = %v, want %v", got2, tt.want2)
-			}
+			ctx := context.Background()
+			registry := &registry{}
+			equal(t, tt.arg1(ctx, registry), nil)
+
+			factory := registry.factories[0]
+			equal(t, factory.name, tt.want1)
+			equal(t, factory.source, tt.want2)
 		})
 	}
 }

--- a/registry.go
+++ b/registry.go
@@ -66,11 +66,11 @@ func (r *registry) validateFactories() error {
 			}
 
 			// Is a factory for this type could be resolved?
-			typeFactories := r.findFactoriesFor(inType)
+			typeFactories := r.findFactories(inType)
 			if len(typeFactories) == 0 {
 				errs = append(errs, fmt.Errorf(
-					"failed to validate argument '%s' (index %d) of factory '%s' from '%s': %w",
-					inType, index, factory.source.name, factory.source.source, ErrServiceNotResolved,
+					"failed to validate argument '%s' (index %d) of '%s' from '%s': %w",
+					inType, index, factory.name, factory.source, ErrServiceNotResolved,
 				))
 				continue
 			}
@@ -80,16 +80,16 @@ func (r *registry) validateFactories() error {
 	// Validate all output types are unique.
 	for _, factory := range r.factories {
 		// Skip factories without output type.
-		if factory.outType == nil {
+		if factory.getOutType() == nil {
 			continue
 		}
 
 		// Validate uniqueness of the factory output type.
-		typeFactories := r.findFactoriesFor(factory.outType)
-		if len(typeFactories) > 1 {
+		factories := r.findFactories(factory.getOutType())
+		if len(factories) > 1 {
 			errs = append(errs, fmt.Errorf(
-				"failed to validate output '%s' of factory '%s' from '%s': %w",
-				factory.outType, factory.source.name, factory.source.source, ErrServiceDuplicated,
+				"failed to validate output '%s' of '%s' from '%s': %w",
+				factory.getOutType(), factory.name, factory.source, ErrServiceDuplicated,
 			))
 		}
 	}
@@ -121,12 +121,12 @@ func (r *registry) validateFactories() error {
 				}
 
 				// Walk through all factories for this in argument type.
-				typeFactories := r.findFactoriesFor(inType)
+				typeFactories := r.findFactories(inType)
 				for _, factoryForType := range typeFactories {
 					if factoryForType == r.factories[index] {
 						errs = append(errs, fmt.Errorf(
-							"failed to validate factory '%s' from '%s': %w",
-							r.factories[index].source.name, r.factories[index].source.source,
+							"failed to validate '%s' from '%s': %w",
+							r.factories[index].name, r.factories[index].source,
 							ErrCircularDependency,
 						))
 						break recursion
@@ -153,7 +153,7 @@ func (r *registry) spawnFactories() error {
 		if err := r.spawnFactory(factory); err != nil {
 			return fmt.Errorf(
 				"failed to spawn services of '%s' from '%s': %w",
-				factory.source.name, factory.source.source, err,
+				factory.name, factory.source, err,
 			)
 		}
 	}
@@ -177,7 +177,7 @@ func (r *registry) closeFactories() error {
 		factory.cancel()
 
 		// Skip factories without output type.
-		if factory.outType == nil {
+		if factory.getOutType() == nil {
 			continue
 		}
 
@@ -191,8 +191,8 @@ func (r *registry) closeFactories() error {
 		if closer, ok := service.(interface{ Close() error }); ok {
 			if err := closer.Close(); err != nil {
 				errs = append(errs, fmt.Errorf(
-					"failed to close service '%s' of factory '%s' from '%s': %w",
-					outValue.Type(), factory.source.name, factory.source.source, err),
+					"failed to close service '%s' of '%s' from '%s': %w",
+					outValue.Type(), factory.name, factory.source, err),
 				)
 			}
 		}
@@ -260,7 +260,7 @@ func (r *registry) resolveMultiple(multipleType, serviceType reflect.Type) (refl
 // resolveRegular resolves a regular service.
 func (r *registry) resolveRegular(serviceType reflect.Type) (reflect.Value, error) {
 	// Resolve all services by specified type.
-	serviceValues, err := r.resolveByType(serviceType)
+	resolvedValues, err := r.resolveByType(serviceType)
 	if err != nil {
 		return reflect.Value{}, err
 	}
@@ -270,18 +270,18 @@ func (r *registry) resolveRegular(serviceType reflect.Type) (reflect.Value, erro
 	// not found, then a zero-value box should be returned instead. For example, resolving an
 	// unregistered type `Config` triggers an error, while resolving `gontainer.Optional[Config]`
 	// returns a zero-value box.
-	if len(serviceValues) == 0 {
+	if len(resolvedValues) == 0 {
 		return reflect.Value{}, fmt.Errorf("%w: '%s'", ErrServiceNotResolved, serviceType)
 	}
 
 	// Pick first found service value.
-	return serviceValues[0], nil
+	return resolvedValues[0], nil
 }
 
 // resolveByType resolves all service fits to specified type.
 func (r *registry) resolveByType(serviceType reflect.Type) ([]reflect.Value, error) {
 	// Lookup factory definition by an output service type.
-	factories := r.findFactoriesFor(serviceType)
+	factories := r.findFactories(serviceType)
 	services := make([]reflect.Value, 0, len(factories))
 
 	for _, factory := range factories {
@@ -297,26 +297,26 @@ func (r *registry) resolveByType(serviceType reflect.Type) ([]reflect.Value, err
 	return services, nil
 }
 
-// findFactoriesFor lookups for all factories for an output type in the registry.
-func (r *registry) findFactoriesFor(serviceType reflect.Type) []*factory {
+// findFactories lookups for all factories for an output type in the registry.
+func (r *registry) findFactories(serviceType reflect.Type) []*factory {
 	var factories []*factory
 
 	// Lookup for factories in the registry.
 	for _, factory := range r.factories {
 		// Skip factories without output type.
-		if factory.outType == nil {
+		if factory.getOutType() == nil {
 			continue
 		}
 
 		// Desired service type matched.
-		if factory.outType == serviceType {
+		if factory.getOutType() == serviceType {
 			factories = append(factories, factory)
 			continue
 		}
 
 		// Desired service type implements an interface.
 		if serviceType.Kind() == reflect.Interface {
-			if factory.outType.Implements(serviceType) {
+			if factory.getOutType().Implements(serviceType) {
 				factories = append(factories, factory)
 				continue
 			}
@@ -339,14 +339,14 @@ func (r *registry) spawnFactory(factory *factory) error {
 	defer factory.spawnMu.Unlock()
 
 	// Check factory already spawned.
-	if factory.getSpawned() {
+	if factory.getIsSpawned() {
 		return nil
 	}
 
 	// Get or spawn factory input values recursively.
 	inValues := make([]reflect.Value, 0, len(factory.inTypes))
 	for _, inType := range factory.inTypes {
-		// Handle specified `context.Context` as a special case.
+		// Handle `context.Context` as a special case.
 		if isContextInterface(inType) {
 			ctxValue := reflect.ValueOf(factory.ctx)
 			inValues = append(inValues, ctxValue)
@@ -362,22 +362,19 @@ func (r *registry) spawnFactory(factory *factory) error {
 		inValues = append(inValues, inValue)
 	}
 
-	// Spawn the factory using input arguments.
+	// Call the factory using input arguments.
 	outValues := factory.funcValue.Call(inValues)
 
-	// Handle factory output error if present.
-	if len(outValues) == 2 && !outValues[1].IsNil() {
-		err, _ := outValues[1].Interface().(error)
+	// Set factory output values.
+	factory.setOutValues(outValues)
+
+	// Handle error returned by the factory.
+	if err := factory.getOutError(); err != nil {
 		return fmt.Errorf("%w: %w", ErrFactoryReturnedError, err)
 	}
 
-	// Save the factory spawn status.
-	factory.setSpawned(true)
-
-	// Save the factory out values.
-	if factory.outType != nil {
-		factory.setOutValue(outValues[0])
-	}
+	// Set the factory spawn status.
+	factory.setIsSpawned(true)
 
 	// Save the factory spawn order.
 	r.mutex.Lock()

--- a/registry_test.go
+++ b/registry_test.go
@@ -35,26 +35,24 @@ func TestRegistryRegisterFactory(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	source := NewFactory(fun)
-	factory, err := source.factory(ctx)
-	equal(t, err, nil)
-
+	option := NewFactory(fun)
 	registry := &registry{}
-	registry.registerFactory(factory)
-	equal(t, registry.factories[0], factory)
-	equal(t, factory.source.fn == nil, false)
+	equal(t, option(ctx, registry), nil)
+	factory := registry.factories[0]
+	equal(t, factory.funcValue.IsValid(), true)
+	equal(t, factory.funcValue.Kind(), reflect.Func)
 }
 
 // TestRegistryValidateFactories tests corresponding registry method.
 func TestRegistryValidateFactories(t *testing.T) {
 	tests := []struct {
-		name      string
-		factories []*Factory
-		wantErr   func(t *testing.T, err error)
+		name    string
+		options []Option
+		wantErr func(t *testing.T, err error)
 	}{
 		{
 			name: "NoValidationErrors",
-			factories: []*Factory{
+			options: []Option{
 				NewFactory(func(bool) (int, error) { return 1, nil }),
 				NewFactory(func(string) (bool, error) { return true, nil }),
 				NewFactory(func() (string, error) { return "s", nil }),
@@ -65,7 +63,7 @@ func TestRegistryValidateFactories(t *testing.T) {
 		},
 		{
 			name: "ServiceNotResolvedError",
-			factories: []*Factory{
+			options: []Option{
 				NewFactory(func(bool) (int, error) { return 0, nil }),
 				NewFactory(func(string) (int32, error) { return 0, nil }),
 			},
@@ -79,18 +77,18 @@ func TestRegistryValidateFactories(t *testing.T) {
 
 				equal(t, errors.Is(errs[0], ErrServiceNotResolved), true)
 				equal(t, errs[0].Error(), "failed to validate argument 'bool' (index 0) "+
-					"of factory 'Factory[func(bool) (int, error)]' from 'github.com/NVIDIA/gontainer': "+
+					"of 'Factory[func(bool) (int, error)]' from 'github.com/NVIDIA/gontainer': "+
 					"service not resolved")
 
 				equal(t, errors.Is(errs[1], ErrServiceNotResolved), true)
 				equal(t, errs[1].Error(), "failed to validate argument 'string' (index 0) "+
-					"of factory 'Factory[func(string) (int32, error)]' from 'github.com/NVIDIA/gontainer': "+
+					"of 'Factory[func(string) (int32, error)]' from 'github.com/NVIDIA/gontainer': "+
 					"service not resolved")
 			},
 		},
 		{
 			name: "ServiceDuplicatedError",
-			factories: []*Factory{
+			options: []Option{
 				NewFactory(func() (string, error) { return "s1", nil }),
 				NewFactory(func() (string, error) { return "s2", nil }),
 			},
@@ -104,18 +102,18 @@ func TestRegistryValidateFactories(t *testing.T) {
 
 				equal(t, errors.Is(errs[0], ErrServiceDuplicated), true)
 				equal(t, errs[0].Error(), "failed to validate output 'string' "+
-					"of factory 'Factory[func() (string, error)]' from 'github.com/NVIDIA/gontainer': "+
+					"of 'Factory[func() (string, error)]' from 'github.com/NVIDIA/gontainer': "+
 					"service duplicated")
 
 				equal(t, errors.Is(errs[1], ErrServiceDuplicated), true)
 				equal(t, errs[1].Error(), "failed to validate output 'string' "+
-					"of factory 'Factory[func() (string, error)]' from 'github.com/NVIDIA/gontainer': "+
+					"of 'Factory[func() (string, error)]' from 'github.com/NVIDIA/gontainer': "+
 					"service duplicated")
 			},
 		},
 		{
 			name: "CircularDependencyErrors",
-			factories: []*Factory{
+			options: []Option{
 				NewFactory(func(bool) (int, error) { return 1, nil }),
 				NewFactory(func(string) (bool, error) { return true, nil }),
 				NewFactory(func(int) (string, error) { return "s", nil }),
@@ -129,21 +127,21 @@ func TestRegistryValidateFactories(t *testing.T) {
 				equal(t, len(errs), 3)
 
 				equal(t, errors.Is(errs[0], ErrCircularDependency), true)
-				equal(t, errs[0].Error(), "failed to validate factory 'Factory[func(bool) (int, error)]' "+
+				equal(t, errs[0].Error(), "failed to validate 'Factory[func(bool) (int, error)]' "+
 					"from 'github.com/NVIDIA/gontainer': circular dependency")
 
 				equal(t, errors.Is(errs[1], ErrCircularDependency), true)
-				equal(t, errs[1].Error(), "failed to validate factory 'Factory[func(string) (bool, error)]' "+
+				equal(t, errs[1].Error(), "failed to validate 'Factory[func(string) (bool, error)]' "+
 					"from 'github.com/NVIDIA/gontainer': circular dependency")
 
 				equal(t, errors.Is(errs[2], ErrCircularDependency), true)
-				equal(t, errs[2].Error(), "failed to validate factory 'Factory[func(int) (string, error)]' "+
+				equal(t, errs[2].Error(), "failed to validate 'Factory[func(int) (string, error)]' "+
 					"from 'github.com/NVIDIA/gontainer': circular dependency")
 			},
 		},
 		{
 			name: "ComplexErrors",
-			factories: []*Factory{
+			options: []Option{
 				NewFactory(func(struct{ X int }) string { return "s1" }),                   // not resolved, duplicate
 				NewFactory(func(ctx context.Context) (string, error) { return "s2", nil }), // duplicate
 				NewFactory(func(bool) (int, error) { return 1, nil }),                      // cycle
@@ -162,30 +160,30 @@ func TestRegistryValidateFactories(t *testing.T) {
 
 				equal(t, errors.Is(errs[0], ErrServiceNotResolved), true)
 				equal(t, errs[0].Error(), "failed to validate argument 'struct { X int }' (index 0) "+
-					"of factory 'Factory[func(struct { X int }) string]' from 'github.com/NVIDIA/gontainer': "+
+					"of 'Factory[func(struct { X int }) string]' from 'github.com/NVIDIA/gontainer': "+
 					"service not resolved")
 
 				equal(t, errors.Is(errs[1], ErrServiceDuplicated), true)
 				equal(t, errs[1].Error(), "failed to validate output 'string' "+
-					"of factory 'Factory[func(struct { X int }) string]' from 'github.com/NVIDIA/gontainer': "+
+					"of 'Factory[func(struct { X int }) string]' from 'github.com/NVIDIA/gontainer': "+
 					"service duplicated")
 
 				equal(t, errors.Is(errs[2], ErrServiceDuplicated), true)
 				equal(t, errs[2].Error(), "failed to validate output 'string' "+
-					"of factory 'Factory[func(context.Context) (string, error)]' from 'github.com/NVIDIA/gontainer': "+
+					"of 'Factory[func(context.Context) (string, error)]' from 'github.com/NVIDIA/gontainer': "+
 					"service duplicated")
 
 				equal(t, errors.Is(errs[3], ErrServiceDuplicated), true)
 				equal(t, errs[3].Error(), "failed to validate output 'string' "+
-					"of factory 'Factory[func() string]' from 'github.com/NVIDIA/gontainer': "+
+					"of 'Factory[func() string]' from 'github.com/NVIDIA/gontainer': "+
 					"service duplicated")
 
 				equal(t, errors.Is(errs[4], ErrCircularDependency), true)
-				equal(t, errs[4].Error(), "failed to validate factory 'Factory[func(bool) (int, error)]' "+
+				equal(t, errs[4].Error(), "failed to validate 'Factory[func(bool) (int, error)]' "+
 					"from 'github.com/NVIDIA/gontainer': circular dependency")
 
 				equal(t, errors.Is(errs[5], ErrCircularDependency), true)
-				equal(t, errs[5].Error(), "failed to validate factory 'Factory[func(int) (bool, error)]' "+
+				equal(t, errs[5].Error(), "failed to validate 'Factory[func(int) (bool, error)]' "+
 					"from 'github.com/NVIDIA/gontainer': circular dependency")
 			},
 		},
@@ -194,11 +192,8 @@ func TestRegistryValidateFactories(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			registry := &registry{}
-			for _, source := range tt.factories {
-				factory, err := source.factory(ctx)
-				equal(t, err, nil)
-				equal(t, factory == nil, false)
-				registry.registerFactory(factory)
+			for _, option := range tt.options {
+				equal(t, option(ctx, registry), nil)
 			}
 			tt.wantErr(t, registry.validateFactories())
 		})
@@ -207,20 +202,21 @@ func TestRegistryValidateFactories(t *testing.T) {
 
 // TestRegistrySpawnFactories tests corresponding registry method.
 func TestRegistrySpawnFactories(t *testing.T) {
-	source := NewFactory(func() bool { return true })
+	option := NewFactory(func() bool {
+		return true
+	})
 
 	ctx := context.Background()
-	factory, err := source.factory(ctx)
-	equal(t, err, nil)
-	equal(t, factory == nil, false)
-
 	registry := &registry{}
-	registry.registerFactory(factory)
 
-	err = registry.spawnFactories()
-	equal(t, err, nil)
-	equal(t, factory.spawned, true)
-	equal(t, factory.outValue.Interface(), true)
+	equal(t, option(ctx, registry), nil)
+	factory := registry.factories[0]
+
+	equal(t, registry.spawnFactories(), nil)
+	equal(t, factory.isSpawned, true)
+	equal(t, len(factory.outValues), 1)
+	equal(t, factory.outValues[0].Interface(), true)
+	equal(t, factory.getOutValue().Interface(), true)
 }
 
 // TestRegistryResolveParallel tests corresponding registry method.
@@ -234,12 +230,10 @@ func TestRegistryResolveParallel(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	factory, err := source.factory(ctx)
-	equal(t, err, nil)
-	equal(t, factory == nil, false)
-
 	registry := &registry{}
-	registry.registerFactory(factory)
+
+	equal(t, source(ctx, registry), nil)
+	factory := registry.factories[0]
 
 	wg := sync.WaitGroup{}
 	wg.Add(10)
@@ -253,7 +247,7 @@ func TestRegistryResolveParallel(t *testing.T) {
 	}
 
 	wg.Wait()
-	equal(t, factory.getSpawned(), true)
+	equal(t, factory.getIsSpawned(), true)
 	equal(t, invocations.Load(), int32(1))
 }
 
@@ -264,7 +258,7 @@ func TestRegistryResolveFuncServices(t *testing.T) {
 	func2Calls := atomic.Int64{}
 	fact3Calls := atomic.Int64{}
 
-	sources := []*Factory{
+	options := []Option{
 		NewFactory(func() func() int {
 			return func() int {
 				func1Calls.Add(1)
@@ -293,11 +287,9 @@ func TestRegistryResolveFuncServices(t *testing.T) {
 
 	ctx := context.Background()
 	registry := &registry{}
-	for _, source := range sources {
-		factory, err := source.factory(ctx)
-		equal(t, err, nil)
-		equal(t, factory == nil, false)
-		registry.registerFactory(factory)
+
+	for _, option := range options {
+		equal(t, option(ctx, registry), nil)
 	}
 
 	err := registry.spawnFactories()
@@ -318,14 +310,10 @@ func TestRegistrySpawnWithErrors(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	factory, err := source.factory(ctx)
-	equal(t, err, nil)
-	equal(t, factory == nil, false)
-
 	registry := &registry{}
-	registry.registerFactory(factory)
+	equal(t, source(ctx, registry), nil)
 
-	err = registry.spawnFactories()
+	err := registry.spawnFactories()
 	equal(t, err != nil, true)
 	equal(t, fmt.Sprint(err), `failed to spawn services of `+
 		`'Factory[func() (bool, error)]' from 'github.com/NVIDIA/gontainer': `+


### PR DESCRIPTION
This pull request refactors the service container and factory registration system to use a new `Option` type instead of the previous `Factory` type. This change streamlines service registration, improves flexibility, and simplifies the API for defining and registering service factories. The update touches core container logic, example service factories, and related tests.

**Core API Refactor:**

* Replaced the `Factory` type with a new `Option` type for registering services and factories. The `Run` function now accepts variadic `Option` arguments instead of `Factory` instances, and all service/factory registration helpers (`NewFactory`, `NewService`) now return `Option`. [[1]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaR23-R27) [[2]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL43-R56) [[3]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaR78-R198) [[4]](diffhunk://#diff-8ae5e92a2a10b4779f44d65dcd9448ae0e189ba6cfa8680209deca1ce9f98d0aL48-L165)

**Example Service Factories Update:**

* Updated all example service factory functions (e.g., `WithAppEndpoints`, `WithConfig`, `WithHTTPServer`, `WithSlogLogger`) to return the new `Option` type, reflecting the API change. [[1]](diffhunk://#diff-3d2c8c0cdd03b67d98fa025f37a5020d9cfa6677f4f731e89b1c82d518de0031L30-R30) [[2]](diffhunk://#diff-3d2c8c0cdd03b67d98fa025f37a5020d9cfa6677f4f731e89b1c82d518de0031L46-R46) [[3]](diffhunk://#diff-3d2c8c0cdd03b67d98fa025f37a5020d9cfa6677f4f731e89b1c82d518de0031L62-R62) [[4]](diffhunk://#diff-8a1636254230c6c7f981bb7011bc18da0f6854df451150624fa89219442ea0abL25-R25) [[5]](diffhunk://#diff-d03687bff08c73805f80f3b070033ece61dbaa822e419991ef0383eb93838b04L82-R82) [[6]](diffhunk://#diff-9435b8130766a2fce1971f24244ffb363c080459c8c028ff4809d01e246aef49L30-R30)

**Internal Factory Representation Improvements:**

* Refactored the internal `factory` struct to support multiple output values, thread-safe accessors, and signature-dependent output handling. Added new getter/setter methods for spawned status and output values, and removed legacy `Factory` methods. [[1]](diffhunk://#diff-8ae5e92a2a10b4779f44d65dcd9448ae0e189ba6cfa8680209deca1ce9f98d0aL203-R146) [[2]](diffhunk://#diff-8ae5e92a2a10b4779f44d65dcd9448ae0e189ba6cfa8680209deca1ce9f98d0aL232-R251)

**Test Suite Adaptation:**

* Updated tests to work with the new `Option` type and revised registration flow. Adjusted assertions to check the new structure and accessors. [[1]](diffhunk://#diff-8046b034a1ad68ce96705decc695bb0b827a75d9817c7043d5c51c41c4f12933R23) [[2]](diffhunk://#diff-8046b034a1ad68ce96705decc695bb0b827a75d9817c7043d5c51c41c4f12933L33-R46) [[3]](diffhunk://#diff-8046b034a1ad68ce96705decc695bb0b827a75d9817c7043d5c51c41c4f12933L55-R59) [[4]](diffhunk://#diff-8046b034a1ad68ce96705decc695bb0b827a75d9817c7043d5c51c41c4f12933L86-R96)

**Registry Validation Consistency:**

* Updated registry validation logic to use new naming and source conventions, reflecting the refactored factory structure.