### PR TITLE
V2 devel: errors refactor

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2003 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gontainer
+
+import (
+	"errors"
+)
+
+// ErrFactoryReturnedError declares factory returned error.
+var ErrFactoryReturnedError = errors.New("factory returned error")
+
+// ErrServiceDuplicated declares service duplicated error.
+var ErrServiceDuplicated = errors.New("service duplicated")
+
+// ErrServiceNotResolved declares service not resolved error.
+var ErrServiceNotResolved = errors.New("service not resolved")
+
+// ErrCircularDependency declares a cyclic dependency error.
+var ErrCircularDependency = errors.New("circular dependency")

--- a/registry.go
+++ b/registry.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"runtime"
 	"sync"
 )
 
@@ -329,11 +328,6 @@ func (r *registry) findFactories(serviceType reflect.Type) []*factory {
 
 // spawnFactory instantiates specified factory definition.
 func (r *registry) spawnFactory(factory *factory) error {
-	// Protect from cyclic dependencies.
-	if getStackDepth() >= stackDepthLimit {
-		return ErrStackLimitReached
-	}
-
 	// Lock the factory spawn mutex.
 	factory.spawnMu.Lock()
 	defer factory.spawnMu.Unlock()
@@ -400,27 +394,3 @@ func isErrorInterface(typ reflect.Type) bool {
 	errType := reflect.TypeOf((*error)(nil)).Elem()
 	return typ.Kind() == reflect.Interface && typ.Implements(errType)
 }
-
-// getStackDepth returns current stack depth.
-func getStackDepth() int {
-	pc := make([]uintptr, stackDepthLimit+1)
-	return runtime.Callers(0, pc) - 1
-}
-
-// stackDepthLimit to protect from infinite recursion.
-const stackDepthLimit = 100
-
-// ErrFactoryReturnedError declares factory returned error.
-var ErrFactoryReturnedError = errors.New("factory returned error")
-
-// ErrServiceDuplicated declares service duplicated error.
-var ErrServiceDuplicated = errors.New("service duplicated")
-
-// ErrServiceNotResolved declares service not resolved error.
-var ErrServiceNotResolved = errors.New("service not resolved")
-
-// ErrCircularDependency declares a cyclic dependency error.
-var ErrCircularDependency = errors.New("circular dependency")
-
-// ErrStackLimitReached declares a reach of stack limit error.
-var ErrStackLimitReached = errors.New("stack limit reached")


### PR DESCRIPTION
This pull request refactors error handling in the codebase by moving error declarations from `registry.go` to a new file, `errors.go`. It also removes the stack depth limit logic that was previously used to prevent infinite recursion in factory spawning. These changes help organize the code better and simplify the factory spawning process.

**Error handling refactor:**

* Added a new file, `errors.go`, to declare error variables such as `ErrFactoryReturnedError`, `ErrServiceDuplicated`, `ErrServiceNotResolved`, and `ErrCircularDependency`, moving them out of `registry.go` for better organization.
* Removed the declaration and usage of `ErrStackLimitReached` and the associated stack depth limit logic (`getStackDepth`, `stackDepthLimit`) from `registry.go`, simplifying the factory spawning process. [[1]](diffhunk://#diff-638576cf5913c90c8eb77dadc04e6834ec3061ae4873d3ed7eeca0a2908a1c63L332-L336) [[2]](diffhunk://#diff-638576cf5913c90c8eb77dadc04e6834ec3061ae4873d3ed7eeca0a2908a1c63L403-L426)

**Code cleanup:**

* Removed the unused `runtime` import from `registry.go` as part of cleaning up stack depth logic.