### PR TITLE
V2 devel: explicit API for closing of factories

### DIFF
--- a/container.go
+++ b/container.go
@@ -86,8 +86,10 @@ type Option func(ctx context.Context, registry *registry) error
 //
 // Example:
 //
-//	gontainer.NewFactory(func(db *Database) (*Handler, error) { ... })
 //	gontainer.NewFactory(func(db *Database) *Handler { ... })
+//	gontainer.NewFactory(func(db *Database) (*Handler, error) { ... })
+//	gontainer.NewFactory(func(db *Database) (*Handler, func() error) { ... })
+//	gontainer.NewFactory(func(db *Database) (*Handler, func() error, error) { ... })
 func NewFactory(function any) Option {
 	funcValue := reflect.ValueOf(function)
 	funcType := reflect.TypeOf(function)
@@ -106,6 +108,7 @@ func NewFactory(function any) Option {
 		// Prepare default value and error getters.
 		var getOutType getOutTypeFn
 		var getOutValue getOutValueFn
+		var getOutClose getOutCloseFn
 		var getOutError getOutErrorFn
 
 		// Prepare value and error getters.
@@ -114,13 +117,29 @@ func NewFactory(function any) Option {
 		case funcType.NumOut() == 1 && isUsefulService(funcType.Out(0)):
 			getOutType = func(outTypes []reflect.Type) reflect.Type { return outTypes[0] }
 			getOutValue = func(outValues []reflect.Value) reflect.Value { return outValues[0] }
+			getOutClose = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
 			getOutError = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
 
 		// Factory returns a service and an error.
 		case funcType.NumOut() == 2 && isUsefulService(funcType.Out(0)) && isErrorInterface(funcType.Out(1)):
 			getOutType = func(outTypes []reflect.Type) reflect.Type { return outTypes[0] }
 			getOutValue = func(outValues []reflect.Value) reflect.Value { return outValues[0] }
+			getOutClose = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
 			getOutError = func(outValues []reflect.Value) reflect.Value { return outValues[1] }
+
+		// Factory returns a service and a close callback.
+		case funcType.NumOut() == 2 && isUsefulService(funcType.Out(0)) && isCloseCallback(funcType.Out(1)):
+			getOutType = func(outTypes []reflect.Type) reflect.Type { return outTypes[0] }
+			getOutValue = func(outValues []reflect.Value) reflect.Value { return outValues[0] }
+			getOutClose = func(outValues []reflect.Value) reflect.Value { return outValues[1] }
+			getOutError = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
+
+		// Factory returns a service, a close callback and an error.
+		case funcType.NumOut() == 3 && isUsefulService(funcType.Out(0)) && isCloseCallback(funcType.Out(1)) && isErrorInterface(funcType.Out(2)):
+			getOutType = func(outTypes []reflect.Type) reflect.Type { return outTypes[0] }
+			getOutValue = func(outValues []reflect.Value) reflect.Value { return outValues[0] }
+			getOutClose = func(outValues []reflect.Value) reflect.Value { return outValues[1] }
+			getOutError = func(outValues []reflect.Value) reflect.Value { return outValues[2] }
 
 		// Factory signature is invalid.
 		default:
@@ -128,7 +147,7 @@ func NewFactory(function any) Option {
 		}
 
 		// Load the factory internal representation.
-		state, err := newFactory(ctx, name, source, funcValue, getOutType, getOutValue, getOutError)
+		state, err := newFactory(ctx, name, source, funcValue, getOutType, getOutValue, getOutClose, getOutError)
 		if err != nil {
 			return fmt.Errorf("failed to load factory '%s': %w", name, err)
 		}
@@ -166,13 +185,12 @@ func NewService[T any](service T) Option {
 	return func(ctx context.Context, registry *registry) error {
 		// Prepare value and error getters.
 		getOutType := func(outTypes []reflect.Type) reflect.Type { return funcType.Out(0) }
-		getOutValue := func(outValues []reflect.Value) reflect.Value {
-			return outValues[0]
-		}
+		getOutValue := func(outValues []reflect.Value) reflect.Value { return outValues[0] }
+		getOutClose := func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
 		getOutError := func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
 
 		// Load the factory internal representation.
-		state, err := newFactory(ctx, name, source, funcValue, getOutType, getOutValue, getOutError)
+		state, err := newFactory(ctx, name, source, funcValue, getOutType, getOutValue, getOutClose, getOutError)
 		if err != nil {
 			return fmt.Errorf("failed to load factory '%s': %w", name, err)
 		}
@@ -209,6 +227,7 @@ func NewFunction(function any) Option {
 		// Prepare default value and error getters.
 		var getOutType getOutTypeFn
 		var getOutValue getOutValueFn
+		var getOutClose getOutCloseFn
 		var getOutError getOutErrorFn
 
 		// Prepare value and error getters.
@@ -217,12 +236,14 @@ func NewFunction(function any) Option {
 		case funcType.NumOut() == 0:
 			getOutType = func(outTypes []reflect.Type) reflect.Type { return nil }
 			getOutValue = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
+			getOutClose = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
 			getOutError = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
 
 		// Function returns an error.
 		case funcType.NumOut() == 1 && isErrorInterface(funcType.Out(0)):
 			getOutType = func(outTypes []reflect.Type) reflect.Type { return nil }
 			getOutValue = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
+			getOutClose = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
 			getOutError = func(outValues []reflect.Value) reflect.Value { return outValues[0] }
 
 		// Function signature is invalid.
@@ -231,7 +252,7 @@ func NewFunction(function any) Option {
 		}
 
 		// Load the factory internal representation.
-		state, err := newFactory(ctx, name, source, funcValue, getOutType, getOutValue, getOutError)
+		state, err := newFactory(ctx, name, source, funcValue, getOutType, getOutValue, getOutClose, getOutError)
 		if err != nil {
 			return fmt.Errorf("failed to load factory '%s': %w", name, err)
 		}

--- a/container_test.go
+++ b/container_test.go
@@ -37,6 +37,8 @@ func TestContainer(t *testing.T) {
 
 	// Prepare started flag.
 	started := atomic.Bool{}
+	closed := atomic.Bool{}
+	invoked := atomic.Bool{}
 
 	// Run container.
 	equal(t, Run(
@@ -50,6 +52,13 @@ func TestContainer(t *testing.T) {
 		NewFactory(func() *testService3 { return svc3 }),
 		NewFactory(func() *testService4 { return svc4 }),
 		NewFactory(func() testService5 { return svc5 }),
+		NewFactory(func() (float32, func() error) {
+			started.Store(true)
+			return 123, func() error {
+				closed.Store(true)
+				return nil
+			}
+		}),
 		NewFunction(func(
 			ctx context.Context,
 			dep1 float64,
@@ -62,6 +71,7 @@ func TestContainer(t *testing.T) {
 			dep8 Optional[testService5],
 			dep9 Optional[interface{ Do5() error }],
 			dep10 Optional[func() error],
+			dep11 float32,
 		) {
 			equal(t, dep1, float64(100500))
 			equal(t, dep2, "string")
@@ -75,12 +85,15 @@ func TestContainer(t *testing.T) {
 			equal(t, dep8.Get().Do5().Error(), "svc5 error")
 			equal(t, dep9.Get().Do5().Error(), "svc5 error")
 			equal(t, dep10.Get(), (func() error)(nil))
-			started.Store(true)
+			equal(t, dep11, float32(123))
+			invoked.Store(true)
 		}),
 	), nil)
 
-	// Assert started flag is set.
+	// Assert flags are set.
 	equal(t, started.Load(), true)
+	equal(t, closed.Load(), true)
+	equal(t, invoked.Load(), true)
 }
 
 type testService1 struct{}

--- a/examples/02_daemon_service/main.go
+++ b/examples/02_daemon_service/main.go
@@ -43,11 +43,6 @@ type MyServer struct {
 	server *http.Server
 }
 
-// Close implements close interface.
-func (s *MyServer) Close() error {
-	return s.server.Shutdown(context.Background())
-}
-
 func main() {
 	// Prepare terminate signals channel.
 	terminate := make(chan os.Signal)
@@ -114,10 +109,12 @@ func main() {
 			select {
 			case err := <-errsChan:
 				logger.Printf("Exiting from serving with error: %s", err)
-				return err
+				closeErr := server.server.Shutdown(context.Background())
+				return errors.Join(err, closeErr)
 			case <-terminate:
 				logger.Println("Exiting from serving by signal")
-				return nil
+				closeErr := server.server.Shutdown(context.Background())
+				return closeErr
 			}
 		}),
 	)

--- a/examples/03_complete_webapp/services/app/factory.go
+++ b/examples/03_complete_webapp/services/app/factory.go
@@ -68,9 +68,12 @@ func WithAppEntryPoint(terminate <-chan os.Signal) gontainer.Option {
 			}
 
 			// Wait for termination signal.
+			logger.Info("Waiting for term signal")
 			<-terminate
-			logger.Info("Terminating by signal")
-			return nil
+			logger.Info("Term signal received")
+
+			// Terminate the server.
+			return server.Close()
 		},
 	)
 }

--- a/examples/03_complete_webapp/services/httpsvr/factory.go
+++ b/examples/03_complete_webapp/services/httpsvr/factory.go
@@ -63,8 +63,7 @@ func (s *Server) Start() error {
 	return nil
 }
 
-// Close function will be automatically called on the container close.
-// See: https://github.com/NVIDIA/gontainer?tab=readme-ov-file#services.
+// Close closes HTTP server.
 func (s *Server) Close() error {
 	// Stop serving HTTP requests.
 	s.logger.Info("Closing HTTP server")

--- a/factory.go
+++ b/factory.go
@@ -64,8 +64,10 @@ func splitFuncName(funcFullName string) (string, string) {
 
 // newFactory loads factory function to the internal representation.
 func newFactory(
-	ctx context.Context, name, source string, funcValue reflect.Value,
-	getOutType getOutTypeFn, getOutValue getOutValueFn, getOutError getOutErrorFn,
+	ctx context.Context,
+	name, source string, funcValue reflect.Value,
+	getOutType getOutTypeFn, getOutValue getOutValueFn,
+	getOutClose getOutCloseFn, getOutError getOutErrorFn,
 ) (*factory, error) {
 	// Prepare function reflect type.
 	funcType := funcValue.Type()
@@ -99,6 +101,7 @@ func newFactory(
 		// Signature-dependent.
 		getOutTypeFn:  getOutType,
 		getOutValueFn: getOutValue,
+		getOutCloseFn: getOutClose,
 		getOutErrorFn: getOutError,
 	}, nil
 }
@@ -149,6 +152,9 @@ type factory struct {
 
 	// Factory output value getter.
 	getOutValueFn getOutValueFn
+
+	// Factory output close getter.
+	getOutCloseFn getOutCloseFn
 
 	// Factory output error getter.
 	getOutErrorFn getOutErrorFn
@@ -223,6 +229,37 @@ func (f *factory) getOutError() error {
 	return nil
 }
 
+// getOutClose returns factory close function in a thread-safe way.
+func (f *factory) getOutClose() func() error {
+	// Get the factory closer value.
+	outValues := f.getOutValues()
+	outValue := f.getOutCloseFn(outValues)
+
+	// Check if the value is valid.
+	if !outValue.IsValid() {
+		return func() error {
+			return nil
+		}
+	}
+
+	// Check if the value is nil.
+	if outValue.IsNil() {
+		return func() error {
+			return nil
+		}
+	}
+
+	// Check if the value is a close function.
+	if closeFunc, ok := outValue.Interface().(func() error); ok {
+		return closeFunc
+	}
+
+	// Return a no-op close function.
+	return func() error {
+		return nil
+	}
+}
+
 // getOutTypeFn is the function type for getting an output type.
 type getOutTypeFn func([]reflect.Type) reflect.Type
 
@@ -231,3 +268,6 @@ type getOutValueFn func([]reflect.Value) reflect.Value
 
 // getOutErrorFn is the function type for getting an output error.
 type getOutErrorFn func([]reflect.Value) reflect.Value
+
+// getOutCloseFn is the function type for getting a close function.
+type getOutCloseFn func([]reflect.Value) reflect.Value

--- a/registry.go
+++ b/registry.go
@@ -198,22 +198,12 @@ func (r *registry) closeFactories() error {
 		// waiting of context done channels and finish work.
 		factory.cancel()
 
-		// Get the factory result object interface.
-		service := factory.getOutValue().Interface()
-
-		// Close service implementing `Close() error` interface.
-		if closer, ok := service.(interface{ Close() error }); ok {
-			if err := closer.Close(); err != nil {
-				errs = append(errs, fmt.Errorf(
-					"failed to close service '%T' of '%s' from '%s': %w",
-					service, factory.name, factory.source, err),
-				)
-			}
-		}
-
-		// Close service implementing `Close()` interface.
-		if closer, ok := service.(interface{ Close() }); ok {
-			closer.Close()
+		// Invoke close callback function.
+		if err := factory.getOutClose()(); err != nil {
+			errs = append(errs, fmt.Errorf(
+				"failed to close '%s' from '%s': %w",
+				factory.name, factory.source, err,
+			))
 		}
 	}
 
@@ -443,4 +433,10 @@ func isContextInterface(typ reflect.Type) bool {
 func isErrorInterface(typ reflect.Type) bool {
 	errType := reflect.TypeOf((*error)(nil)).Elem()
 	return typ.Kind() == reflect.Interface && typ.Implements(errType)
+}
+
+// isCloseCallback returns true when argument is a close callback function.
+func isCloseCallback(typ reflect.Type) bool {
+	refType := reflect.TypeOf(func() error { return nil })
+	return typ.Kind() == reflect.Func && typ == refType
 }


### PR DESCRIPTION
This pull request enhances the dependency injection container to support factories that return a close callback function, allowing services to define custom cleanup logic. It introduces a new mechanism for extracting and invoking close callbacks, updates the container's factory registration and shutdown logic, and adds comprehensive tests to verify the new functionality.

### Container API and Factory Registration

* Extended the `NewFactory`, `NewService`, and `NewFunction` APIs to support factories returning a close callback (`func() error`) and updated their internal handling to extract and store this callback. This allows service factories to return not only the service and error, but also a close function for custom resource cleanup. [[1]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL89-R92) [[2]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaR111) [[3]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaR120-R150) [[4]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL169-R193) [[5]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaR230) [[6]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaR239-R246) [[7]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL234-R255)

* Updated the internal factory representation (`factory.go`) to store and retrieve the close callback via a new `getOutCloseFn` field and method. [[1]](diffhunk://#diff-8ae5e92a2a10b4779f44d65dcd9448ae0e189ba6cfa8680209deca1ce9f98d0aL67-R70) [[2]](diffhunk://#diff-8ae5e92a2a10b4779f44d65dcd9448ae0e189ba6cfa8680209deca1ce9f98d0aR104) [[3]](diffhunk://#diff-8ae5e92a2a10b4779f44d65dcd9448ae0e189ba6cfa8680209deca1ce9f98d0aR156-R158) [[4]](diffhunk://#diff-8ae5e92a2a10b4779f44d65dcd9448ae0e189ba6cfa8680209deca1ce9f98d0aR232-R262) [[5]](diffhunk://#diff-8ae5e92a2a10b4779f44d65dcd9448ae0e189ba6cfa8680209deca1ce9f98d0aR271-R273)

### Container Shutdown Logic

* Modified the container shutdown process to invoke the close callback returned by each factory, rather than relying solely on the `Close()` method of the service object. This ensures all registered cleanup logic is executed, regardless of how the service is structured.

* Added a utility to detect close callback signatures (`isCloseCallback`) for robust factory signature validation.

### Testing and Examples

* Added new tests to verify that factories returning close callbacks are correctly invoked during container shutdown, and updated assertions to check that all flags (started, closed, invoked) are set as expected. [[1]](diffhunk://#diff-b1eb9afa48ad78a73fcc18342b9da970021b71d1eb6cf6e391a80012a31cbfd3R40-R41) [[2]](diffhunk://#diff-b1eb9afa48ad78a73fcc18342b9da970021b71d1eb6cf6e391a80012a31cbfd3R55-R61) [[3]](diffhunk://#diff-b1eb9afa48ad78a73fcc18342b9da970021b71d1eb6cf6e391a80012a31cbfd3R74) [[4]](diffhunk://#diff-b1eb9afa48ad78a73fcc18342b9da970021b71d1eb6cf6e391a80012a31cbfd3L78-R96)

* Updated example services and main application logic to use the new close callback mechanism, improving clarity and demonstrating proper usage. [[1]](diffhunk://#diff-4fb90c3fe40c80e8fb4b126f0075a5bbed6e14144eafbd1c549a655e430a12feL46-L50) [[2]](diffhunk://#diff-4fb90c3fe40c80e8fb4b126f0075a5bbed6e14144eafbd1c549a655e430a12feL117-R117) [[3]](diffhunk://#diff-3d2c8c0cdd03b67d98fa025f37a5020d9cfa6677f4f731e89b1c82d518de0031R71-R76) [[4]](diffhunk://#diff-d03687bff08c73805f80f3b070033ece61dbaa822e419991ef0383eb93838b04L66-R66)