### PR TITLE
V2 devel: switch to the new module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![GoDoc](https://pkg.go.dev/badge/github.com/NVIDIA/gontainer)](https://pkg.go.dev/github.com/NVIDIA/gontainer)
+[![GoDoc](https://pkg.go.dev/badge/github.com/NVIDIA/gontainer/v2)](https://pkg.go.dev/github.com/NVIDIA/gontainer/v2)
 ![Test](https://github.com/NVIDIA/gontainer/actions/workflows/go.yml/badge.svg)
-[![Report](https://goreportcard.com/badge/github.com/NVIDIA/gontainer)](https://goreportcard.com/report/github.com/NVIDIA/gontainer)
+[![Report](https://goreportcard.com/badge/github.com/NVIDIA/gontainer/v2)](https://goreportcard.com/report/github.com/NVIDIA/gontainer/v2)
 
 # Gontainer
 
@@ -28,7 +28,7 @@ package main
 import (
     "context"
     "log"
-    "github.com/NVIDIA/gontainer"
+    "github.com/NVIDIA/gontainer/v2"
 )
 
 // Your services
@@ -104,7 +104,7 @@ func main() {
 ## Installation
 
 ```bash
-go get github.com/NVIDIA/gontainer@latest
+go get github.com/NVIDIA/gontainer/v2
 ```
 
 Requirements: Go 1.21+

--- a/examples/01_console_command/go.mod
+++ b/examples/01_console_command/go.mod
@@ -4,6 +4,6 @@ go 1.21
 
 toolchain go1.21.0
 
-require github.com/NVIDIA/gontainer v0.0.0-00010101000000-000000000000
+require github.com/NVIDIA/gontainer/v2 v2.0.0-00010101000000-000000000000
 
-replace github.com/NVIDIA/gontainer => ../../
+replace github.com/NVIDIA/gontainer/v2 => ../../

--- a/examples/01_console_command/main.go
+++ b/examples/01_console_command/main.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"log"
 
-	"github.com/NVIDIA/gontainer"
+	"github.com/NVIDIA/gontainer/v2"
 )
 
 // NameService is a service that returns a name.

--- a/examples/02_daemon_service/go.mod
+++ b/examples/02_daemon_service/go.mod
@@ -4,6 +4,6 @@ go 1.21
 
 toolchain go1.21.0
 
-require github.com/NVIDIA/gontainer v0.0.0-00010101000000-000000000000
+require github.com/NVIDIA/gontainer/v2 v2.0.0-00010101000000-000000000000
 
-replace github.com/NVIDIA/gontainer => ../../
+replace github.com/NVIDIA/gontainer/v2 => ../../

--- a/examples/02_daemon_service/main.go
+++ b/examples/02_daemon_service/main.go
@@ -27,7 +27,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/NVIDIA/gontainer"
+	"github.com/NVIDIA/gontainer/v2"
 )
 
 // MyService performs some crucial tasks.

--- a/examples/03_complete_webapp/go.mod
+++ b/examples/03_complete_webapp/go.mod
@@ -4,6 +4,6 @@ go 1.21
 
 toolchain go1.21.0
 
-require github.com/NVIDIA/gontainer v0.0.0-00010101000000-000000000000
+require github.com/NVIDIA/gontainer/v2 v2.0.0-00010101000000-000000000000
 
-replace github.com/NVIDIA/gontainer => ../../
+replace github.com/NVIDIA/gontainer/v2 => ../../

--- a/examples/03_complete_webapp/main.go
+++ b/examples/03_complete_webapp/main.go
@@ -23,11 +23,11 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/NVIDIA/gontainer"
 	"github.com/NVIDIA/gontainer/examples/03_complete_webapp/services/app"
 	"github.com/NVIDIA/gontainer/examples/03_complete_webapp/services/config"
 	"github.com/NVIDIA/gontainer/examples/03_complete_webapp/services/httpsvr"
 	"github.com/NVIDIA/gontainer/examples/03_complete_webapp/services/logging"
+	"github.com/NVIDIA/gontainer/v2"
 )
 
 // Example of the environment configuration.

--- a/examples/03_complete_webapp/services/app/factory.go
+++ b/examples/03_complete_webapp/services/app/factory.go
@@ -22,8 +22,8 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/NVIDIA/gontainer"
 	"github.com/NVIDIA/gontainer/examples/03_complete_webapp/services/httpsvr"
+	"github.com/NVIDIA/gontainer/v2"
 )
 
 // WithAppEndpoints returns a factory which configures app endpoints.

--- a/examples/03_complete_webapp/services/config/factory.go
+++ b/examples/03_complete_webapp/services/config/factory.go
@@ -18,7 +18,7 @@
 package config
 
 import (
-	"github.com/NVIDIA/gontainer"
+	"github.com/NVIDIA/gontainer/v2"
 )
 
 // WithConfig returns a factory for the Config service.

--- a/examples/03_complete_webapp/services/httpsvr/factory.go
+++ b/examples/03_complete_webapp/services/httpsvr/factory.go
@@ -24,8 +24,8 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/NVIDIA/gontainer"
 	confmod "github.com/NVIDIA/gontainer/examples/03_complete_webapp/services/config"
+	"github.com/NVIDIA/gontainer/v2"
 )
 
 // Server is an HTTP server service.

--- a/examples/03_complete_webapp/services/logging/factory.go
+++ b/examples/03_complete_webapp/services/logging/factory.go
@@ -22,8 +22,8 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/NVIDIA/gontainer"
 	confmod "github.com/NVIDIA/gontainer/examples/03_complete_webapp/services/config"
+	"github.com/NVIDIA/gontainer/v2"
 )
 
 // WithSlogLogger returns a factory for the slog logger.

--- a/examples/04_transient_services/go.mod
+++ b/examples/04_transient_services/go.mod
@@ -4,6 +4,6 @@ go 1.21
 
 toolchain go1.21.0
 
-require github.com/NVIDIA/gontainer v0.0.0-00010101000000-000000000000
+require github.com/NVIDIA/gontainer/v2 v2.0.0-00010101000000-000000000000
 
-replace github.com/NVIDIA/gontainer => ../../
+replace github.com/NVIDIA/gontainer/v2 => ../../

--- a/examples/04_transient_services/main.go
+++ b/examples/04_transient_services/main.go
@@ -22,7 +22,7 @@ import (
 	"log"
 	"math/rand"
 
-	"github.com/NVIDIA/gontainer"
+	"github.com/NVIDIA/gontainer/v2"
 )
 
 func main() {

--- a/factory_test.go
+++ b/factory_test.go
@@ -64,25 +64,25 @@ func TestFactoryInfo(t *testing.T) {
 			name:  "ServiceLocalType",
 			arg1:  NewService(localType{}),
 			want1: "Service[gontainer.localType]",
-			want2: "github.com/NVIDIA/gontainer",
+			want2: "github.com/NVIDIA/gontainer/v2",
 		},
 		{
 			name:  "ServiceGlobalType",
 			arg1:  NewService(globalType{}),
 			want1: "Service[gontainer.globalType]",
-			want2: "github.com/NVIDIA/gontainer",
+			want2: "github.com/NVIDIA/gontainer/v2",
 		},
 		{
 			name:  "FactoryLocalFunc",
 			arg1:  NewFactory(localFunc),
 			want1: "Factory[func(gontainer.globalType) string]",
-			want2: "github.com/NVIDIA/gontainer",
+			want2: "github.com/NVIDIA/gontainer/v2",
 		},
 		{
 			name:  "FactoryGlobalFunc",
 			arg1:  NewFactory(globalFunc),
 			want1: "Factory[func(string) bool]",
-			want2: "github.com/NVIDIA/gontainer",
+			want2: "github.com/NVIDIA/gontainer/v2",
 		},
 	}
 	for _, tt := range tests {
@@ -113,8 +113,8 @@ func TestSplitFuncName(t *testing.T) {
 		want2 string
 	}{{
 		name:  "SplitPublicPackage",
-		arg:   "github.com/NVIDIA/gontainer/app.WithApp.func1",
-		want1: "github.com/NVIDIA/gontainer/app",
+		arg:   "github.com/NVIDIA/gontainer/v2/app.WithApp.func1",
+		want1: "github.com/NVIDIA/gontainer/v2/app",
 		want2: "WithApp.func1",
 	}, {
 		name:  "SplitMainPackage",

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/NVIDIA/gontainer
+module github.com/NVIDIA/gontainer/v2
 
 go 1.21

--- a/registry_test.go
+++ b/registry_test.go
@@ -77,12 +77,12 @@ func TestRegistryValidateFactories(t *testing.T) {
 
 				equal(t, errors.Is(errs[0], ErrServiceNotResolved), true)
 				equal(t, errs[0].Error(), "failed to validate argument 'bool' (index 0) "+
-					"of 'Factory[func(bool) (int, error)]' from 'github.com/NVIDIA/gontainer': "+
+					"of 'Factory[func(bool) (int, error)]' from 'github.com/NVIDIA/gontainer/v2': "+
 					"service not resolved")
 
 				equal(t, errors.Is(errs[1], ErrServiceNotResolved), true)
 				equal(t, errs[1].Error(), "failed to validate argument 'string' (index 0) "+
-					"of 'Factory[func(string) (int32, error)]' from 'github.com/NVIDIA/gontainer': "+
+					"of 'Factory[func(string) (int32, error)]' from 'github.com/NVIDIA/gontainer/v2': "+
 					"service not resolved")
 			},
 		},
@@ -102,12 +102,12 @@ func TestRegistryValidateFactories(t *testing.T) {
 
 				equal(t, errors.Is(errs[0], ErrServiceDuplicated), true)
 				equal(t, errs[0].Error(), "failed to validate output 'string' "+
-					"of 'Factory[func() (string, error)]' from 'github.com/NVIDIA/gontainer': "+
+					"of 'Factory[func() (string, error)]' from 'github.com/NVIDIA/gontainer/v2': "+
 					"service duplicated")
 
 				equal(t, errors.Is(errs[1], ErrServiceDuplicated), true)
 				equal(t, errs[1].Error(), "failed to validate output 'string' "+
-					"of 'Factory[func() (string, error)]' from 'github.com/NVIDIA/gontainer': "+
+					"of 'Factory[func() (string, error)]' from 'github.com/NVIDIA/gontainer/v2': "+
 					"service duplicated")
 			},
 		},
@@ -128,15 +128,15 @@ func TestRegistryValidateFactories(t *testing.T) {
 
 				equal(t, errors.Is(errs[0], ErrCircularDependency), true)
 				equal(t, errs[0].Error(), "failed to validate 'Factory[func(bool) (int, error)]' "+
-					"from 'github.com/NVIDIA/gontainer': circular dependency")
+					"from 'github.com/NVIDIA/gontainer/v2': circular dependency")
 
 				equal(t, errors.Is(errs[1], ErrCircularDependency), true)
 				equal(t, errs[1].Error(), "failed to validate 'Factory[func(string) (bool, error)]' "+
-					"from 'github.com/NVIDIA/gontainer': circular dependency")
+					"from 'github.com/NVIDIA/gontainer/v2': circular dependency")
 
 				equal(t, errors.Is(errs[2], ErrCircularDependency), true)
 				equal(t, errs[2].Error(), "failed to validate 'Factory[func(int) (string, error)]' "+
-					"from 'github.com/NVIDIA/gontainer': circular dependency")
+					"from 'github.com/NVIDIA/gontainer/v2': circular dependency")
 			},
 		},
 		{
@@ -161,36 +161,36 @@ func TestRegistryValidateFactories(t *testing.T) {
 
 				equal(t, errors.Is(errs[0], ErrServiceNotResolved), true)
 				equal(t, errs[0].Error(), "failed to validate argument 'struct { X int }' (index 0) "+
-					"of 'Factory[func(struct { X int }) string]' from 'github.com/NVIDIA/gontainer': "+
+					"of 'Factory[func(struct { X int }) string]' from 'github.com/NVIDIA/gontainer/v2': "+
 					"service not resolved")
 
 				equal(t, errors.Is(errs[1], ErrServiceNotResolved), true)
 				equal(t, errs[1].Error(), "failed to validate argument 'struct { X int }' (index 0) "+
-					"of 'Function[func(struct { X int }) error]' from 'github.com/NVIDIA/gontainer': "+
+					"of 'Function[func(struct { X int }) error]' from 'github.com/NVIDIA/gontainer/v2': "+
 					"service not resolved")
 
 				equal(t, errors.Is(errs[2], ErrServiceDuplicated), true)
 				equal(t, errs[2].Error(), "failed to validate output 'string' "+
-					"of 'Factory[func(struct { X int }) string]' from 'github.com/NVIDIA/gontainer': "+
+					"of 'Factory[func(struct { X int }) string]' from 'github.com/NVIDIA/gontainer/v2': "+
 					"service duplicated")
 
 				equal(t, errors.Is(errs[3], ErrServiceDuplicated), true)
 				equal(t, errs[3].Error(), "failed to validate output 'string' "+
-					"of 'Factory[func(context.Context) (string, error)]' from 'github.com/NVIDIA/gontainer': "+
+					"of 'Factory[func(context.Context) (string, error)]' from 'github.com/NVIDIA/gontainer/v2': "+
 					"service duplicated")
 
 				equal(t, errors.Is(errs[4], ErrServiceDuplicated), true)
 				equal(t, errs[4].Error(), "failed to validate output 'string' "+
-					"of 'Factory[func() string]' from 'github.com/NVIDIA/gontainer': "+
+					"of 'Factory[func() string]' from 'github.com/NVIDIA/gontainer/v2': "+
 					"service duplicated")
 
 				equal(t, errors.Is(errs[5], ErrCircularDependency), true)
 				equal(t, errs[5].Error(), "failed to validate 'Factory[func(bool) (int, error)]' "+
-					"from 'github.com/NVIDIA/gontainer': circular dependency")
+					"from 'github.com/NVIDIA/gontainer/v2': circular dependency")
 
 				equal(t, errors.Is(errs[6], ErrCircularDependency), true)
 				equal(t, errs[6].Error(), "failed to validate 'Factory[func(int) (bool, error)]' "+
-					"from 'github.com/NVIDIA/gontainer': circular dependency")
+					"from 'github.com/NVIDIA/gontainer/v2': circular dependency")
 			},
 		},
 	}
@@ -319,7 +319,7 @@ func TestRegistryResolveWithErrors(t *testing.T) {
 	equal(t, err != nil, true)
 	equal(t, value.IsValid(), false)
 	equal(t, fmt.Sprint(err), `failed to spawn `+
-		`'Factory[func() (bool, error)]' from 'github.com/NVIDIA/gontainer': `+
+		`'Factory[func() (bool, error)]' from 'github.com/NVIDIA/gontainer/v2': `+
 		`factory returned error: some function-specific error message`)
 	equal(t, errors.Is(err, ErrFactoryReturnedError), true)
 }
@@ -337,7 +337,7 @@ func TestRegistryInvokeWithErrors(t *testing.T) {
 	err := registry.invokeFunctions()
 	equal(t, err != nil, true)
 	equal(t, fmt.Sprint(err), `failed to invoke `+
-		`'Function[func() error]' from 'github.com/NVIDIA/gontainer': `+
+		`'Function[func() error]' from 'github.com/NVIDIA/gontainer/v2': `+
 		`function returned error: some function-specific error message`)
 	equal(t, errors.Is(err, ErrFunctionReturnedError), true)
 }


### PR DESCRIPTION
This pull request updates the project to use the new Go module path `github.com/NVIDIA/gontainer/v2` throughout the codebase and documentation. The changes ensure consistency and compatibility with Go module versioning for v2 and later releases. The most important changes are grouped below:

**Module path migration:**

* Changed the module path in `go.mod` from `github.com/NVIDIA/gontainer` to `github.com/NVIDIA/gontainer/v2`, establishing the v2 module.
* Updated all import statements in example code and service factories to use `github.com/NVIDIA/gontainer/v2` instead of the previous path. [[1]](diffhunk://#diff-aeeaf3883448a89ac0c0e17bd2ad35d1f5921f2080fd41728fcf2bb0b3889789L24-R24) [[2]](diffhunk://#diff-4fb90c3fe40c80e8fb4b126f0075a5bbed6e14144eafbd1c549a655e430a12feL30-R30) [[3]](diffhunk://#diff-37fa79737982ae151ec4b0c41e5bee41486bf7cdc2b99f1093271e088ee7756dL26-R30) [[4]](diffhunk://#diff-3d2c8c0cdd03b67d98fa025f37a5020d9cfa6677f4f731e89b1c82d518de0031L25-R26) [[5]](diffhunk://#diff-8a1636254230c6c7f981bb7011bc18da0f6854df451150624fa89219442ea0abL21-R21) [[6]](diffhunk://#diff-d03687bff08c73805f80f3b070033ece61dbaa822e419991ef0383eb93838b04L27-R28) [[7]](diffhunk://#diff-9435b8130766a2fce1971f24244ffb363c080459c8c028ff4809d01e246aef49L25-R26) [[8]](diffhunk://#diff-28131f7cb8ae4b4088a6363f39aa778435d26179a078c36d5a3b3a56c629a1a8L25-R25)

**Documentation updates:**

* Modified badges and installation instructions in `README.md` to reference the new v2 module path, ensuring users install the correct version. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L2-R4) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R31) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L107-R107)

**Example project configuration:**

* Updated all example `go.mod` files to require and replace `github.com/NVIDIA/gontainer/v2` instead of the previous path. [[1]](diffhunk://#diff-4a74007aded698eddaf9bacfaa891ed1189a2d1b69c9226ec3aed2b085cbad20L7-R9) [[2]](diffhunk://#diff-513c4e70fab218d7d8c0bbca33e44a5ace388f5f48eaf8e9e5da40ee4cebb9edL7-R9) [[3]](diffhunk://#diff-5ad0202ef946e4b0044c52f4523c22eb62271154f1ae5422097794deb582fc82L7-R9) [[4]](diffhunk://#diff-a6a5601085782fcc208baa322dd9661b04de81f2dfe6470fe8de58db2a57ae21L7-R9)

**Test suite adjustments:**

* Updated test assertions in `factory_test.go` and `registry_test.go` to expect the new module path in type and error messages, ensuring tests reflect the migration. [[1]](diffhunk://#diff-8046b034a1ad68ce96705decc695bb0b827a75d9817c7043d5c51c41c4f12933L67-R85) [[2]](diffhunk://#diff-8046b034a1ad68ce96705decc695bb0b827a75d9817c7043d5c51c41c4f12933L116-R117) [[3]](diffhunk://#diff-edb24508617964ec78bbd08114140588702e64b9d1f8fce9540cf3162f0c38f3L80-R85) [[4]](diffhunk://#diff-edb24508617964ec78bbd08114140588702e64b9d1f8fce9540cf3162f0c38f3L105-R110) [[5]](diffhunk://#diff-edb24508617964ec78bbd08114140588702e64b9d1f8fce9540cf3162f0c38f3L131-R139) [[6]](diffhunk://#diff-edb24508617964ec78bbd08114140588702e64b9d1f8fce9540cf3162f0c38f3L164-R193) [[7]](diffhunk://#diff-edb24508617964ec78bbd08114140588702e64b9d1f8fce9540cf3162f0c38f3L322-R322) [[8]](diffhunk://#diff-edb24508617964ec78bbd08114140588702e64b9d1f8fce9540cf3162f0c38f3L340-R340)