### PR TITLE
V2 devel: features to check option types

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,15 @@ func NewService[T any](service T) Option
 
 // NewEntrypoint registers an entrypoint function.
 func NewEntrypoint(fn any) Option
+
+// IsFactory checks if the given option is a factory.
+func IsFactory(option Option) bool
+
+// IsService checks if the given option is a service.
+func IsService(option Option) bool
+
+// IsEntrypoint checks if the given option is an entrypoint.
+func IsEntrypoint(option Option) bool
 ```
 
 ### Factory Signatures

--- a/container.go
+++ b/container.go
@@ -41,18 +41,18 @@ func Run(ctx context.Context, options ...Option) error {
 	invoker := &Invoker{resolver: resolver}
 
 	// Register service resolver instance in the registry.
-	if err := NewService(resolver)(ctx, registry); err != nil {
+	if err := NewService(resolver).apply(ctx, registry); err != nil {
 		return fmt.Errorf("failed to register resolver: %w", err)
 	}
 
 	// Register function invoker instance in the registry.
-	if err := NewService(invoker)(ctx, registry); err != nil {
+	if err := NewService(invoker).apply(ctx, registry); err != nil {
 		return fmt.Errorf("failed to register invoker: %w", err)
 	}
 
 	// Register provided factories in the registry.
 	for _, option := range options {
-		if err := option(ctx, registry); err != nil {
+		if err := option.apply(ctx, registry); err != nil {
 			return fmt.Errorf("failed to apply option: %w", err)
 		}
 	}
@@ -77,7 +77,13 @@ func Run(ctx context.Context, options ...Option) error {
 }
 
 // Option defines an option for the service container.
-type Option func(ctx context.Context, registry *registry) error
+type Option interface {
+	// apply applies the option to the given context and registry.
+	apply(context.Context, *registry) error
+
+	// kind returns associated with the option kind string.
+	kind() string
+}
 
 // NewFactory creates a new service load using the provided load function.
 //
@@ -99,7 +105,7 @@ func NewFactory(function any) Option {
 	source := getFuncSource(funcValue)
 
 	// Prepare option callback.
-	return func(ctx context.Context, registry *registry) error {
+	return newOption(func(ctx context.Context, registry *registry) error {
 		// Validate function type.
 		if funcType.Kind() != reflect.Func {
 			return fmt.Errorf("invalid type: %s", funcType)
@@ -157,7 +163,7 @@ func NewFactory(function any) Option {
 
 		// Factory registered.
 		return nil
-	}
+	}, "factory")
 }
 
 // NewService creates a new service load that always returns the given singleton value.
@@ -182,7 +188,7 @@ func NewService[T any](service T) Option {
 	source := serviceType.PkgPath()
 
 	// Prepare option callback.
-	return func(ctx context.Context, registry *registry) error {
+	return newOption(func(ctx context.Context, registry *registry) error {
 		// Prepare value and error getters.
 		getOutType := func(outTypes []reflect.Type) reflect.Type { return funcType.Out(0) }
 		getOutValue := func(outValues []reflect.Value) reflect.Value { return outValues[0] }
@@ -200,7 +206,7 @@ func NewService[T any](service T) Option {
 
 		// Factory registered.
 		return nil
-	}
+	}, "service")
 }
 
 // NewEntrypoint creates a new factory which will be called by the container.
@@ -218,7 +224,7 @@ func NewEntrypoint(function any) Option {
 	source := getFuncSource(funcValue)
 
 	// Prepare option callback.
-	return func(ctx context.Context, registry *registry) error {
+	return newOption(func(ctx context.Context, registry *registry) error {
 		// Validate function type.
 		if funcType.Kind() != reflect.Func {
 			return fmt.Errorf("invalid type: %s", funcType)
@@ -262,5 +268,41 @@ func NewEntrypoint(function any) Option {
 
 		// Factory registered.
 		return nil
-	}
+	}, "entrypoint")
+}
+
+// IsFactory checks if the given option is a factory.
+func IsFactory(option Option) bool {
+	return option.kind() == "factory"
+}
+
+// IsService checks if the given option is a service.
+func IsService(option Option) bool {
+	return option.kind() == "service"
+}
+
+// IsEntrypoint checks if the given option is an entrypoint.
+func IsEntrypoint(option Option) bool {
+	return option.kind() == "entrypoint"
+}
+
+// newOption creates a new option with the given apply function.
+func newOption(apply func(context.Context, *registry) error, kind string) Option {
+	return &option{fn: apply, knd: kind}
+}
+
+// option implements Option interface.
+type option struct {
+	fn  func(context.Context, *registry) error
+	knd string
+}
+
+// apply applies the option to the given context and registry.
+func (o *option) apply(ctx context.Context, registry *registry) error {
+	return o.fn(ctx, registry)
+}
+
+// String returns a human-readable description of the option.
+func (o *option) kind() string {
+	return o.knd
 }


### PR DESCRIPTION
This pull request refactors the service container's option handling to use an interface-based approach, improving type safety and extensibility. The main changes include replacing the function-based `Option` type with an interface, introducing option kind identification, and adding helper functions for option type checking.

### Refactoring Option Handling

* Changed the `Option` type from a function to an interface with `apply` and `kind` methods, allowing for more structured and extensible option management. (`container.go`)
* Updated `NewFactory`, `NewService`, and `NewEntrypoint` to return the new `Option` interface, and replaced direct function returns with a `newOption` constructor that sets the option kind. (`container.go`) [[1]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL102-R108) [[2]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL160-R166) [[3]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL185-R191) [[4]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL203-R209) [[5]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL221-R227)

### Option Type Identification

* Added helper functions `IsFactory`, `IsService`, and `IsEntrypoint` to check the kind of an option, improving clarity and usability when working with different option types. (`container.go`, `README.md`) [[1]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaR271-R307) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R280-R288)

### Internal Implementation Improvements

* Introduced the `option` struct to implement the `Option` interface, encapsulating the option logic and kind string. (`container.go`)
* Updated the main container logic to use the new `apply` method for registering options, replacing direct function calls. (`container.go`)

These changes make the service container more robust and easier to extend with new option types in the future.