### PR TITLE
V2 devel: options interface improvement

### DIFF
--- a/container.go
+++ b/container.go
@@ -41,18 +41,18 @@ func Run(ctx context.Context, options ...Option) error {
 	invoker := &Invoker{resolver: resolver}
 
 	// Register service resolver instance in the registry.
-	if err := NewService(resolver)(ctx, registry); err != nil {
+	if err := NewService(resolver).apply(ctx, registry); err != nil {
 		return fmt.Errorf("failed to register resolver: %w", err)
 	}
 
 	// Register function invoker instance in the registry.
-	if err := NewService(invoker)(ctx, registry); err != nil {
+	if err := NewService(invoker).apply(ctx, registry); err != nil {
 		return fmt.Errorf("failed to register invoker: %w", err)
 	}
 
 	// Register provided factories in the registry.
 	for _, option := range options {
-		if err := option(ctx, registry); err != nil {
+		if err := option.apply(ctx, registry); err != nil {
 			return fmt.Errorf("failed to apply option: %w", err)
 		}
 	}
@@ -77,7 +77,10 @@ func Run(ctx context.Context, options ...Option) error {
 }
 
 // Option defines an option for the service container.
-type Option func(ctx context.Context, registry *registry) error
+type Option interface {
+	// apply applies the option to the given registry.
+	apply(ctx context.Context, registry *registry) error
+}
 
 // NewFactory creates a new service load using the provided load function.
 //
@@ -99,65 +102,67 @@ func NewFactory(function any) Option {
 	source := getFuncSource(funcValue)
 
 	// Prepare option callback.
-	return func(ctx context.Context, registry *registry) error {
-		// Validate function type.
-		if funcType.Kind() != reflect.Func {
-			return fmt.Errorf("invalid type: %s", funcType)
-		}
+	return newOption(
+		func(ctx context.Context, registry *registry) error {
+			// Validate function type.
+			if funcType.Kind() != reflect.Func {
+				return fmt.Errorf("invalid type: %s", funcType)
+			}
 
-		// Prepare default value and error getters.
-		var getOutType getOutTypeFn
-		var getOutValue getOutValueFn
-		var getOutClose getOutCloseFn
-		var getOutError getOutErrorFn
+			// Prepare default value and error getters.
+			var getOutType getOutTypeFn
+			var getOutValue getOutValueFn
+			var getOutClose getOutCloseFn
+			var getOutError getOutErrorFn
 
-		// Prepare value and error getters.
-		switch {
-		// Factory returns exactly one service.
-		case funcType.NumOut() == 1 && isUsefulService(funcType.Out(0)):
-			getOutType = func(outTypes []reflect.Type) reflect.Type { return outTypes[0] }
-			getOutValue = func(outValues []reflect.Value) reflect.Value { return outValues[0] }
-			getOutClose = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
-			getOutError = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
+			// Prepare value and error getters.
+			switch {
+			// Factory returns exactly one service.
+			case funcType.NumOut() == 1 && isUsefulService(funcType.Out(0)):
+				getOutType = func(outTypes []reflect.Type) reflect.Type { return outTypes[0] }
+				getOutValue = func(outValues []reflect.Value) reflect.Value { return outValues[0] }
+				getOutClose = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
+				getOutError = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
 
-		// Factory returns a service and an error.
-		case funcType.NumOut() == 2 && isUsefulService(funcType.Out(0)) && isErrorInterface(funcType.Out(1)):
-			getOutType = func(outTypes []reflect.Type) reflect.Type { return outTypes[0] }
-			getOutValue = func(outValues []reflect.Value) reflect.Value { return outValues[0] }
-			getOutClose = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
-			getOutError = func(outValues []reflect.Value) reflect.Value { return outValues[1] }
+			// Factory returns a service and an error.
+			case funcType.NumOut() == 2 && isUsefulService(funcType.Out(0)) && isErrorInterface(funcType.Out(1)):
+				getOutType = func(outTypes []reflect.Type) reflect.Type { return outTypes[0] }
+				getOutValue = func(outValues []reflect.Value) reflect.Value { return outValues[0] }
+				getOutClose = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
+				getOutError = func(outValues []reflect.Value) reflect.Value { return outValues[1] }
 
-		// Factory returns a service and a close callback.
-		case funcType.NumOut() == 2 && isUsefulService(funcType.Out(0)) && isCloseCallback(funcType.Out(1)):
-			getOutType = func(outTypes []reflect.Type) reflect.Type { return outTypes[0] }
-			getOutValue = func(outValues []reflect.Value) reflect.Value { return outValues[0] }
-			getOutClose = func(outValues []reflect.Value) reflect.Value { return outValues[1] }
-			getOutError = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
+			// Factory returns a service and a close callback.
+			case funcType.NumOut() == 2 && isUsefulService(funcType.Out(0)) && isCloseCallback(funcType.Out(1)):
+				getOutType = func(outTypes []reflect.Type) reflect.Type { return outTypes[0] }
+				getOutValue = func(outValues []reflect.Value) reflect.Value { return outValues[0] }
+				getOutClose = func(outValues []reflect.Value) reflect.Value { return outValues[1] }
+				getOutError = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
 
-		// Factory returns a service, a close callback and an error.
-		case funcType.NumOut() == 3 && isUsefulService(funcType.Out(0)) && isCloseCallback(funcType.Out(1)) && isErrorInterface(funcType.Out(2)):
-			getOutType = func(outTypes []reflect.Type) reflect.Type { return outTypes[0] }
-			getOutValue = func(outValues []reflect.Value) reflect.Value { return outValues[0] }
-			getOutClose = func(outValues []reflect.Value) reflect.Value { return outValues[1] }
-			getOutError = func(outValues []reflect.Value) reflect.Value { return outValues[2] }
+			// Factory returns a service, a close callback and an error.
+			case funcType.NumOut() == 3 && isUsefulService(funcType.Out(0)) && isCloseCallback(funcType.Out(1)) && isErrorInterface(funcType.Out(2)):
+				getOutType = func(outTypes []reflect.Type) reflect.Type { return outTypes[0] }
+				getOutValue = func(outValues []reflect.Value) reflect.Value { return outValues[0] }
+				getOutClose = func(outValues []reflect.Value) reflect.Value { return outValues[1] }
+				getOutError = func(outValues []reflect.Value) reflect.Value { return outValues[2] }
 
-		// Factory signature is invalid.
-		default:
-			return fmt.Errorf("invalid signature: %s", funcType)
-		}
+			// Factory signature is invalid.
+			default:
+				return fmt.Errorf("invalid signature: %s", funcType)
+			}
 
-		// Load the factory internal representation.
-		state, err := newFactory(ctx, name, source, funcValue, getOutType, getOutValue, getOutClose, getOutError)
-		if err != nil {
-			return fmt.Errorf("failed to load factory '%s': %w", name, err)
-		}
+			// Load the factory internal representation.
+			state, err := newFactory(ctx, name, source, funcValue, getOutType, getOutValue, getOutClose, getOutError)
+			if err != nil {
+				return fmt.Errorf("failed to load %s: %w", name, err)
+			}
 
-		// Register factory in the registry.
-		registry.registerFactory(state)
+			// Register factory in the registry.
+			registry.registerFactory(state)
 
-		// Factory registered.
-		return nil
-	}
+			// Factory registered.
+			return nil
+		},
+	)
 }
 
 // NewService creates a new service load that always returns the given singleton value.
@@ -182,25 +187,27 @@ func NewService[T any](service T) Option {
 	source := serviceType.PkgPath()
 
 	// Prepare option callback.
-	return func(ctx context.Context, registry *registry) error {
-		// Prepare value and error getters.
-		getOutType := func(outTypes []reflect.Type) reflect.Type { return funcType.Out(0) }
-		getOutValue := func(outValues []reflect.Value) reflect.Value { return outValues[0] }
-		getOutClose := func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
-		getOutError := func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
+	return newOption(
+		func(ctx context.Context, registry *registry) error {
+			// Prepare value and error getters.
+			getOutType := func(outTypes []reflect.Type) reflect.Type { return funcType.Out(0) }
+			getOutValue := func(outValues []reflect.Value) reflect.Value { return outValues[0] }
+			getOutClose := func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
+			getOutError := func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
 
-		// Load the factory internal representation.
-		state, err := newFactory(ctx, name, source, funcValue, getOutType, getOutValue, getOutClose, getOutError)
-		if err != nil {
-			return fmt.Errorf("failed to load factory '%s': %w", name, err)
-		}
+			// Load the factory internal representation.
+			state, err := newFactory(ctx, name, source, funcValue, getOutType, getOutValue, getOutClose, getOutError)
+			if err != nil {
+				return fmt.Errorf("failed to load %s: %w", name, err)
+			}
 
-		// Register factory in the registry.
-		registry.registerFactory(state)
+			// Register factory in the registry.
+			registry.registerFactory(state)
 
-		// Factory registered.
-		return nil
-	}
+			// Factory registered.
+			return nil
+		},
+	)
 }
 
 // NewEntrypoint creates a new factory which will be called by the container.
@@ -218,49 +225,66 @@ func NewEntrypoint(function any) Option {
 	source := getFuncSource(funcValue)
 
 	// Prepare option callback.
-	return func(ctx context.Context, registry *registry) error {
-		// Validate function type.
-		if funcType.Kind() != reflect.Func {
-			return fmt.Errorf("invalid type: %s", funcType)
-		}
+	return newOption(
+		func(ctx context.Context, registry *registry) error {
+			// Validate function type.
+			if funcType.Kind() != reflect.Func {
+				return fmt.Errorf("invalid type: %s", funcType)
+			}
 
-		// Prepare default value and error getters.
-		var getOutType getOutTypeFn
-		var getOutValue getOutValueFn
-		var getOutClose getOutCloseFn
-		var getOutError getOutErrorFn
+			// Prepare default value and error getters.
+			var getOutType getOutTypeFn
+			var getOutValue getOutValueFn
+			var getOutClose getOutCloseFn
+			var getOutError getOutErrorFn
 
-		// Prepare value and error getters.
-		switch {
-		// Function returns nothing.
-		case funcType.NumOut() == 0:
-			getOutType = func(outTypes []reflect.Type) reflect.Type { return nil }
-			getOutValue = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
-			getOutClose = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
-			getOutError = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
+			// Prepare value and error getters.
+			switch {
+			// Function returns nothing.
+			case funcType.NumOut() == 0:
+				getOutType = func(outTypes []reflect.Type) reflect.Type { return nil }
+				getOutValue = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
+				getOutClose = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
+				getOutError = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
 
-		// Function returns an error.
-		case funcType.NumOut() == 1 && isErrorInterface(funcType.Out(0)):
-			getOutType = func(outTypes []reflect.Type) reflect.Type { return nil }
-			getOutValue = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
-			getOutClose = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
-			getOutError = func(outValues []reflect.Value) reflect.Value { return outValues[0] }
+			// Function returns an error.
+			case funcType.NumOut() == 1 && isErrorInterface(funcType.Out(0)):
+				getOutType = func(outTypes []reflect.Type) reflect.Type { return nil }
+				getOutValue = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
+				getOutClose = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
+				getOutError = func(outValues []reflect.Value) reflect.Value { return outValues[0] }
 
-		// Function signature is invalid.
-		default:
-			return fmt.Errorf("invalid signature: %s", funcType)
-		}
+			// Function signature is invalid.
+			default:
+				return fmt.Errorf("invalid signature: %s", funcType)
+			}
 
-		// Load the factory internal representation.
-		state, err := newFactory(ctx, name, source, funcValue, getOutType, getOutValue, getOutClose, getOutError)
-		if err != nil {
-			return fmt.Errorf("failed to load factory '%s': %w", name, err)
-		}
+			// Load the factory internal representation.
+			state, err := newFactory(ctx, name, source, funcValue, getOutType, getOutValue, getOutClose, getOutError)
+			if err != nil {
+				return fmt.Errorf("failed to load %s: %w", name, err)
+			}
 
-		// Register factory in the registry.
-		registry.registerEntrypoint(state)
+			// Register factory in the registry.
+			registry.registerEntrypoint(state)
 
-		// Factory registered.
-		return nil
-	}
+			// Factory registered.
+			return nil
+		},
+	)
+}
+
+// newOption creates a new option instance.
+func newOption(apply func(ctx context.Context, registry *registry) error) *option {
+	return &option{applyFn: apply}
+}
+
+// option is the option based on the internal function.
+type option struct {
+	applyFn func(ctx context.Context, registry *registry) error
+}
+
+// apply applies the option to the given registry.
+func (o *option) apply(ctx context.Context, registry *registry) error {
+	return o.applyFn(ctx, registry)
 }

--- a/factory_test.go
+++ b/factory_test.go
@@ -33,7 +33,7 @@ func TestFactoryLoad(t *testing.T) {
 	ctx := context.Background()
 	option := NewFactory(fun)
 	registry := &registry{}
-	equal(t, option(ctx, registry), nil)
+	equal(t, option.apply(ctx, registry), nil)
 	factory := registry.factories[0]
 
 	equal(t, factory.funcType.String(), "func(string, string, string) (int, error)")
@@ -89,7 +89,7 @@ func TestFactoryInfo(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			registry := &registry{}
-			equal(t, tt.arg1(ctx, registry), nil)
+			equal(t, tt.arg1.apply(ctx, registry), nil)
 
 			factory := registry.factories[0]
 			equal(t, factory.name, tt.want1)

--- a/registry_test.go
+++ b/registry_test.go
@@ -37,7 +37,7 @@ func TestRegistryRegisterFactory(t *testing.T) {
 	ctx := context.Background()
 	option := NewFactory(fun)
 	registry := &registry{}
-	equal(t, option(ctx, registry), nil)
+	equal(t, option.apply(ctx, registry), nil)
 	factory := registry.factories[0]
 	equal(t, factory.funcValue.IsValid(), true)
 	equal(t, factory.funcValue.Kind(), reflect.Func)
@@ -208,7 +208,7 @@ func TestRegistryValidateFactories(t *testing.T) {
 			ctx := context.Background()
 			registry := &registry{}
 			for _, option := range tt.options {
-				equal(t, option(ctx, registry), nil)
+				equal(t, option.apply(ctx, registry), nil)
 			}
 			tt.wantErr(t, registry.validateRegistry())
 		})
@@ -221,8 +221,8 @@ func TestRegistryInvokeFunctions(t *testing.T) {
 	registry := &registry{}
 	invoked := atomic.Bool{}
 
-	equal(t, NewFactory(func() bool { return true })(ctx, registry), nil)
-	equal(t, NewEntrypoint(func(_ bool) { invoked.Store(true) })(ctx, registry), nil)
+	equal(t, NewFactory(func() bool { return true }).apply(ctx, registry), nil)
+	equal(t, NewEntrypoint(func(_ bool) { invoked.Store(true) }).apply(ctx, registry), nil)
 
 	factory := registry.factories[0]
 	equal(t, registry.invokeEntrypoints(), nil)
@@ -246,7 +246,7 @@ func TestRegistryResolveParallel(t *testing.T) {
 	ctx := context.Background()
 	registry := &registry{}
 
-	equal(t, source(ctx, registry), nil)
+	equal(t, source.apply(ctx, registry), nil)
 	factory := registry.factories[0]
 
 	wg := sync.WaitGroup{}
@@ -300,7 +300,7 @@ func TestRegistryResolveFuncServices(t *testing.T) {
 	ctx := context.Background()
 	registry := &registry{}
 	for _, option := range options {
-		equal(t, option(ctx, registry), nil)
+		equal(t, option.apply(ctx, registry), nil)
 	}
 
 	err := registry.invokeEntrypoints()
@@ -322,7 +322,7 @@ func TestRegistryResolveWithErrors(t *testing.T) {
 
 	ctx := context.Background()
 	registry := &registry{}
-	equal(t, source(ctx, registry), nil)
+	equal(t, source.apply(ctx, registry), nil)
 
 	value, err := registry.resolveService(reflect.TypeOf(true))
 	equal(t, err != nil, true)
@@ -341,7 +341,7 @@ func TestRegistryInvokeWithErrors(t *testing.T) {
 
 	ctx := context.Background()
 	registry := &registry{}
-	equal(t, source(ctx, registry), nil)
+	equal(t, source.apply(ctx, registry), nil)
 
 	err := registry.invokeEntrypoints()
 	equal(t, err != nil, true)


### PR DESCRIPTION
This pull request refactors how options are handled in the service container by changing the `Option` type from a function to an interface with an `apply` method. This enables a more extensible and object-oriented approach to option management. The changes affect both the core container logic and related tests, ensuring all option usages now call the `apply` method.

Core API changes:

* Refactored the `Option` type in `container.go` from a function to an interface with an `apply` method, and updated all usages to call `apply` instead of invoking the function directly. [[1]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL80-R83) [[2]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL44-R55)
* Added the `option` struct and `newOption` helper function to implement the new `Option` interface and encapsulate option logic.

Factory and service registration:

* Updated `NewFactory`, `NewService`, and `NewEntrypoint` to return an `Option` instance using the new interface, and updated error messages for consistency. [[1]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL102-R106) [[2]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL152-R165) [[3]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL185-R191) [[4]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL195-R210) [[5]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL221-R229) [[6]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL257-R289)

Test updates:

* Refactored all test usages of options in `factory_test.go` and `registry_test.go` to call the `apply` method instead of invoking the function directly, ensuring compatibility with the new interface. [[1]](diffhunk://#diff-8046b034a1ad68ce96705decc695bb0b827a75d9817c7043d5c51c41c4f12933L36-R36) [[2]](diffhunk://#diff-8046b034a1ad68ce96705decc695bb0b827a75d9817c7043d5c51c41c4f12933L92-R92) [[3]](diffhunk://#diff-edb24508617964ec78bbd08114140588702e64b9d1f8fce9540cf3162f0c38f3L40-R40) [[4]](diffhunk://#diff-edb24508617964ec78bbd08114140588702e64b9d1f8fce9540cf3162f0c38f3L211-R211) [[5]](diffhunk://#diff-edb24508617964ec78bbd08114140588702e64b9d1f8fce9540cf3162f0c38f3L224-R225) [[6]](diffhunk://#diff-edb24508617964ec78bbd08114140588702e64b9d1f8fce9540cf3162f0c38f3L249-R249) [[7]](diffhunk://#diff-edb24508617964ec78bbd08114140588702e64b9d1f8fce9540cf3162f0c38f3L303-R303) [[8]](diffhunk://#diff-edb24508617964ec78bbd08114140588702e64b9d1f8fce9540cf3162f0c38f3L325-R325) [[9]](diffhunk://#diff-edb24508617964ec78bbd08114140588702e64b9d1f8fce9540cf3162f0c38f3L344-R344)