### PR TITLE
Link to the V1 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,3 +366,6 @@ We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guid
 
 Apache 2.0 – See [LICENSE](LICENSE) for details.
 
+## Documentation for `v1`
+
+Documentation for the previous major version `v1` is available at [v1 branch](https://github.com/NVIDIA/gontainer/tree/v1).


### PR DESCRIPTION
This pull request adds a new section to the `README.md` to clarify where documentation for the previous major version (`v1`) can be found.

* Documentation: Added a "Documentation for `v1`" section to the `README.md`, linking to the `v1` branch for users who need information about the previous major version.