### PR TITLE
Introduction of factory and entrypoint options

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,17 +266,17 @@ gontainer.NewEntrypoint(func(newTx func() *Transaction) {
 Gontainer module interface is really simple:
 
 ```go
-// Run creates and runs a container with provided options.
-func Run(ctx context.Context, opts ...Option) error
+// Run creates and runs a container with provided factories and entrypoints.
+func Run(ctx context.Context, opts ...option) error
 
 // NewFactory registers a service factory.
-func NewFactory(fn any) Option
+func NewFactory(fn any) *Factory
 
 // NewService registers a pre-created service.
-func NewService[T any](service T) Option
+func NewService[T any](service T) *Factory
 
 // NewEntrypoint registers an entrypoint function.
-func NewEntrypoint(fn any) Option
+func NewEntrypoint(fn any) *Entrypoint
 ```
 
 ### Factory Signatures

--- a/container.go
+++ b/container.go
@@ -24,7 +24,7 @@ import (
 )
 
 // Run runs a container with a set of configured factories.
-func Run(ctx context.Context, options ...Option) error {
+func Run(ctx context.Context, options ...option) error {
 	// Prepare container context ignoring the cancelling.
 	// When cancelled, it closes `container.Done()` channel
 	// and unblocks any waiting read from `container.Done()`.
@@ -76,10 +76,19 @@ func Run(ctx context.Context, options ...Option) error {
 	return nil
 }
 
-// Option defines an option for the service container.
-type Option interface {
-	// apply applies the option to the given registry.
+// option is the internal interface for container options.
+type option interface {
 	apply(ctx context.Context, registry *registry) error
+}
+
+// Factory is a container option that registers a service factory or singleton.
+type Factory struct {
+	fn func(ctx context.Context, registry *registry) error
+}
+
+// apply applies the factory option to the given registry.
+func (f *Factory) apply(ctx context.Context, registry *registry) error {
+	return f.fn(ctx, registry)
 }
 
 // NewFactory creates a new service load using the provided load function.
@@ -93,7 +102,7 @@ type Option interface {
 //	gontainer.NewFactory(func(db *Database) (*Handler, error) { ... })
 //	gontainer.NewFactory(func(db *Database) (*Handler, func() error) { ... })
 //	gontainer.NewFactory(func(db *Database) (*Handler, func() error, error) { ... })
-func NewFactory(function any) Option {
+func NewFactory(function any) *Factory {
 	funcValue := reflect.ValueOf(function)
 	funcType := reflect.TypeOf(function)
 
@@ -102,8 +111,8 @@ func NewFactory(function any) Option {
 	source := getFuncSource(funcValue)
 
 	// Prepare option callback.
-	return newOption(
-		func(ctx context.Context, registry *registry) error {
+	return &Factory{
+		fn: func(ctx context.Context, registry *registry) error {
 			// Validate function type.
 			if funcType.Kind() != reflect.Func {
 				return fmt.Errorf("invalid type: %s", funcType)
@@ -162,7 +171,7 @@ func NewFactory(function any) Option {
 			// Factory registered.
 			return nil
 		},
-	)
+	}
 }
 
 // NewService creates a new service load that always returns the given singleton value.
@@ -176,7 +185,7 @@ func NewFactory(function any) Option {
 //
 //	logger := NewLogger()
 //	gontainer.NewService(logger)
-func NewService[T any](service T) Option {
+func NewService[T any](service T) *Factory {
 	function := func() T { return service }
 	funcValue := reflect.ValueOf(function)
 	funcType := reflect.TypeOf(function)
@@ -187,8 +196,8 @@ func NewService[T any](service T) Option {
 	source := serviceType.PkgPath()
 
 	// Prepare option callback.
-	return newOption(
-		func(ctx context.Context, registry *registry) error {
+	return &Factory{
+		fn: func(ctx context.Context, registry *registry) error {
 			// Prepare value and error getters.
 			getOutType := func(outTypes []reflect.Type) reflect.Type { return funcType.Out(0) }
 			getOutValue := func(outValues []reflect.Value) reflect.Value { return outValues[0] }
@@ -207,7 +216,17 @@ func NewService[T any](service T) Option {
 			// Factory registered.
 			return nil
 		},
-	)
+	}
+}
+
+// Entrypoint is a container option that registers an entrypoint function.
+type Entrypoint struct {
+	fn func(ctx context.Context, registry *registry) error
+}
+
+// apply applies the entrypoint option to the given registry.
+func (e *Entrypoint) apply(ctx context.Context, registry *registry) error {
+	return e.fn(ctx, registry)
 }
 
 // NewEntrypoint creates a new factory which will be called by the container.
@@ -216,7 +235,7 @@ func NewService[T any](service T) Option {
 //
 //	gontainer.NewEntrypoint(func(db *Database) error { ... })
 //	gontainer.NewEntrypoint(func(db *Database) { ... })
-func NewEntrypoint(function any) Option {
+func NewEntrypoint(function any) *Entrypoint {
 	funcValue := reflect.ValueOf(function)
 	funcType := reflect.TypeOf(function)
 
@@ -225,8 +244,8 @@ func NewEntrypoint(function any) Option {
 	source := getFuncSource(funcValue)
 
 	// Prepare option callback.
-	return newOption(
-		func(ctx context.Context, registry *registry) error {
+	return &Entrypoint{
+		fn: func(ctx context.Context, registry *registry) error {
 			// Validate function type.
 			if funcType.Kind() != reflect.Func {
 				return fmt.Errorf("invalid type: %s", funcType)
@@ -265,26 +284,11 @@ func NewEntrypoint(function any) Option {
 				return fmt.Errorf("failed to load %s: %w", name, err)
 			}
 
-			// Register factory in the registry.
+			// Register entrypoint in the registry.
 			registry.registerEntrypoint(state)
 
-			// Factory registered.
+			// Entrypoint registered.
 			return nil
 		},
-	)
-}
-
-// newOption creates a new option instance.
-func newOption(apply func(ctx context.Context, registry *registry) error) *option {
-	return &option{applyFn: apply}
-}
-
-// option is the option based on the internal function.
-type option struct {
-	applyFn func(ctx context.Context, registry *registry) error
-}
-
-// apply applies the option to the given registry.
-func (o *option) apply(ctx context.Context, registry *registry) error {
-	return o.applyFn(ctx, registry)
+	}
 }

--- a/examples/03_complete_webapp/services/app/factory.go
+++ b/examples/03_complete_webapp/services/app/factory.go
@@ -27,7 +27,7 @@ import (
 )
 
 // WithAppEndpoints returns a factory which configures app endpoints.
-func WithAppEndpoints() gontainer.Option {
+func WithAppEndpoints() *gontainer.Entrypoint {
 	return gontainer.NewEntrypoint(
 		func(logger *slog.Logger, server *httpsvr.Server) {
 			logger = logger.With("service", "app")
@@ -43,7 +43,7 @@ func WithAppEndpoints() gontainer.Option {
 }
 
 // WithHealthEndpoints returns a factory which configures health check endpoints.
-func WithHealthEndpoints() gontainer.Option {
+func WithHealthEndpoints() *gontainer.Entrypoint {
 	return gontainer.NewEntrypoint(
 		func(logger *slog.Logger, server *httpsvr.Server) {
 			logger = logger.With("service", "app")
@@ -59,7 +59,7 @@ func WithHealthEndpoints() gontainer.Option {
 }
 
 // WithAppEntryPoint returns a factory which performs final app start and waits for termination.
-func WithAppEntryPoint(terminate <-chan os.Signal) gontainer.Option {
+func WithAppEntryPoint(terminate <-chan os.Signal) *gontainer.Entrypoint {
 	return gontainer.NewEntrypoint(
 		func(logger *slog.Logger, server *httpsvr.Server) error {
 			// Start serving requests.

--- a/examples/03_complete_webapp/services/config/factory.go
+++ b/examples/03_complete_webapp/services/config/factory.go
@@ -22,7 +22,7 @@ import (
 )
 
 // WithConfig returns a factory for the Config service.
-func WithConfig() gontainer.Option {
+func WithConfig() *gontainer.Factory {
 	return gontainer.NewFactory(func() *Config {
 		return NewConfig()
 	})

--- a/examples/03_complete_webapp/services/httpsvr/factory.go
+++ b/examples/03_complete_webapp/services/httpsvr/factory.go
@@ -78,7 +78,7 @@ func (s *Server) Close() error {
 }
 
 // WithHTTPServer returns a factory for the HTTP server service.
-func WithHTTPServer() gontainer.Option {
+func WithHTTPServer() *gontainer.Factory {
 	return gontainer.NewFactory(
 		func(logger *slog.Logger, confsvc *confmod.Config) (*Server, error) {
 			// Prepare HTTP server config.

--- a/examples/03_complete_webapp/services/logging/factory.go
+++ b/examples/03_complete_webapp/services/logging/factory.go
@@ -27,7 +27,7 @@ import (
 )
 
 // WithSlogLogger returns a factory for the slog logger.
-func WithSlogLogger() gontainer.Option {
+func WithSlogLogger() *gontainer.Factory {
 	return gontainer.NewFactory(
 		func(confsvc *confmod.Config) (*slog.Logger, error) {
 			// Prepare logger config.

--- a/factory_test.go
+++ b/factory_test.go
@@ -56,7 +56,7 @@ func TestFactoryInfo(t *testing.T) {
 
 	tests := []struct {
 		name  string
-		arg1  Option
+		arg1  *Factory
 		want1 string
 		want2 string
 	}{

--- a/registry_test.go
+++ b/registry_test.go
@@ -47,12 +47,12 @@ func TestRegistryRegisterFactory(t *testing.T) {
 func TestRegistryValidateFactories(t *testing.T) {
 	tests := []struct {
 		name    string
-		options []Option
+		options []option
 		wantErr func(t *testing.T, err error)
 	}{
 		{
 			name: "NoValidationErrors",
-			options: []Option{
+			options: []option{
 				NewFactory(func(bool) (int, error) { return 1, nil }),
 				NewFactory(func(string) (bool, error) { return true, nil }),
 				NewFactory(func() (string, error) { return "s", nil }),
@@ -64,7 +64,7 @@ func TestRegistryValidateFactories(t *testing.T) {
 		},
 		{
 			name: "ServiceNotResolvedError",
-			options: []Option{
+			options: []option{
 				NewFactory(func(bool) (int, error) { return 0, nil }),
 				NewFactory(func(string) (int32, error) { return 0, nil }),
 				NewEntrypoint(func(int, int32) {}),
@@ -90,7 +90,7 @@ func TestRegistryValidateFactories(t *testing.T) {
 		},
 		{
 			name: "ServiceDuplicatedError",
-			options: []Option{
+			options: []option{
 				NewFactory(func() (string, error) { return "s1", nil }),
 				NewFactory(func() (string, error) { return "s2", nil }),
 				NewEntrypoint(func(string) {}),
@@ -116,7 +116,7 @@ func TestRegistryValidateFactories(t *testing.T) {
 		},
 		{
 			name: "CircularDependencyErrors",
-			options: []Option{
+			options: []option{
 				NewFactory(func(bool) (int, error) { return 1, nil }),
 				NewFactory(func(string) (bool, error) { return true, nil }),
 				NewFactory(func(int) (string, error) { return "s", nil }),
@@ -148,7 +148,7 @@ func TestRegistryValidateFactories(t *testing.T) {
 		},
 		{
 			name: "ComplexErrors",
-			options: []Option{
+			options: []option{
 				NewFactory(func(struct{ X int }) string { return "s1" }),                   // not resolved, duplicate
 				NewFactory(func(ctx context.Context) (string, error) { return "s2", nil }), // duplicate
 				NewFactory(func(bool) (int, error) { return 1, nil }),                      // cycle
@@ -271,7 +271,7 @@ func TestRegistryResolveFuncServices(t *testing.T) {
 	func2Calls := atomic.Int64{}
 	fact3Calls := atomic.Int64{}
 
-	options := []Option{
+	options := []option{
 		NewFactory(func() func() int {
 			return func() int {
 				func1Calls.Add(1)


### PR DESCRIPTION
Introduce Factory and Entrypoint types, and update related functions.

This pull request refactors the container option system to improve type safety and clarity by replacing the generic `Option` interface with concrete types for factories and entrypoints. The change affects the core API, the README documentation, and several example and test files. The most important changes are summarized below:

### Core API Refactoring

* Introduced concrete `Factory` and `Entrypoint` types, each implementing an internal `option` interface for registration within the container. 

* Updated the signatures of `NewFactory`, `NewService`, and `NewEntrypoint` to return pointers to their respective types (`*Factory`, `*Entrypoint`) instead of the generic `Option` interface.

### Documentation Updates

* Updated the `README.md` to reflect the new API, showing the new return types for `Run`, `NewFactory`, `NewService`, and `NewEntrypoint`.