### PR TITLE
Refactor Factory and Entrypoint types to support annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Gontainer module interface is really simple:
 
 ```go
 // Run creates and runs a container with provided factories and entrypoints.
-func Run(ctx context.Context, opts ...option) error
+func Run(ctx context.Context, opts ...Option) error
 
 // NewFactory registers a service factory.
 func NewFactory(fn any) *Factory

--- a/container.go
+++ b/container.go
@@ -83,7 +83,19 @@ type option interface {
 
 // Factory is a container option that registers a service factory or singleton.
 type Factory struct {
-	fn func(ctx context.Context, registry *registry) error
+	fn     func(ctx context.Context, registry *registry) error
+	name   string
+	source string
+}
+
+// Name returns the human-readable name of the factory.
+func (f *Factory) Name() string {
+	return f.name
+}
+
+// Source returns the source package path of the factory.
+func (f *Factory) Source() string {
+	return f.source
 }
 
 // apply applies the factory option to the given registry.
@@ -112,6 +124,8 @@ func NewFactory(function any) *Factory {
 
 	// Prepare option callback.
 	return &Factory{
+		name:   name,
+		source: source,
 		fn: func(ctx context.Context, registry *registry) error {
 			// Validate function type.
 			if funcType.Kind() != reflect.Func {
@@ -197,6 +211,8 @@ func NewService[T any](service T) *Factory {
 
 	// Prepare option callback.
 	return &Factory{
+		name:   name,
+		source: source,
 		fn: func(ctx context.Context, registry *registry) error {
 			// Prepare value and error getters.
 			getOutType := func(outTypes []reflect.Type) reflect.Type { return funcType.Out(0) }
@@ -221,7 +237,19 @@ func NewService[T any](service T) *Factory {
 
 // Entrypoint is a container option that registers an entrypoint function.
 type Entrypoint struct {
-	fn func(ctx context.Context, registry *registry) error
+	fn     func(ctx context.Context, registry *registry) error
+	name   string
+	source string
+}
+
+// Name returns the human-readable name of the entrypoint.
+func (e *Entrypoint) Name() string {
+	return e.name
+}
+
+// Source returns the source package path of the entrypoint.
+func (e *Entrypoint) Source() string {
+	return e.source
 }
 
 // apply applies the entrypoint option to the given registry.
@@ -245,6 +273,8 @@ func NewEntrypoint(function any) *Entrypoint {
 
 	// Prepare option callback.
 	return &Entrypoint{
+		name:   name,
+		source: source,
 		fn: func(ctx context.Context, registry *registry) error {
 			// Validate function type.
 			if funcType.Kind() != reflect.Func {

--- a/container.go
+++ b/container.go
@@ -24,7 +24,7 @@ import (
 )
 
 // Run runs a container with a set of configured factories.
-func Run(ctx context.Context, options ...option) error {
+func Run(ctx context.Context, options ...Option) error {
 	// Prepare container context ignoring the cancelling.
 	// When cancelled, it closes `container.Done()` channel
 	// and unblocks any waiting read from `container.Done()`.
@@ -76,8 +76,8 @@ func Run(ctx context.Context, options ...option) error {
 	return nil
 }
 
-// option is the internal interface for container options.
-type option interface {
+// Option is the interface for container options.
+type Option interface {
 	apply(ctx context.Context, registry *registry) error
 }
 

--- a/container.go
+++ b/container.go
@@ -81,28 +81,6 @@ type option interface {
 	apply(ctx context.Context, registry *registry) error
 }
 
-// Factory is a container option that registers a service factory or singleton.
-type Factory struct {
-	fn     func(ctx context.Context, registry *registry) error
-	name   string
-	source string
-}
-
-// Name returns the human-readable name of the factory.
-func (f *Factory) Name() string {
-	return f.name
-}
-
-// Source returns the source package path of the factory.
-func (f *Factory) Source() string {
-	return f.source
-}
-
-// apply applies the factory option to the given registry.
-func (f *Factory) apply(ctx context.Context, registry *registry) error {
-	return f.fn(ctx, registry)
-}
-
 // NewFactory creates a new service load using the provided load function.
 //
 // The load function must be a function. It may accept dependencies as input parameters and return
@@ -235,26 +213,26 @@ func NewService[T any](service T) *Factory {
 	}
 }
 
-// Entrypoint is a container option that registers an entrypoint function.
-type Entrypoint struct {
-	fn     func(ctx context.Context, registry *registry) error
+// Factory is a container option that registers a service factory or singleton.
+type Factory struct {
 	name   string
 	source string
+	fn     func(ctx context.Context, registry *registry) error
 }
 
-// Name returns the human-readable name of the entrypoint.
-func (e *Entrypoint) Name() string {
-	return e.name
+// Name returns the human-readable name of the factory.
+func (f *Factory) Name() string {
+	return f.name
 }
 
-// Source returns the source package path of the entrypoint.
-func (e *Entrypoint) Source() string {
-	return e.source
+// Source returns the source package path of the factory.
+func (f *Factory) Source() string {
+	return f.source
 }
 
-// apply applies the entrypoint option to the given registry.
-func (e *Entrypoint) apply(ctx context.Context, registry *registry) error {
-	return e.fn(ctx, registry)
+// apply applies the factory option to the given registry.
+func (f *Factory) apply(ctx context.Context, registry *registry) error {
+	return f.fn(ctx, registry)
 }
 
 // NewEntrypoint creates a new factory which will be called by the container.
@@ -321,4 +299,26 @@ func NewEntrypoint(function any) *Entrypoint {
 			return nil
 		},
 	}
+}
+
+// Entrypoint is a container option that registers an entrypoint function.
+type Entrypoint struct {
+	name   string
+	source string
+	fn     func(ctx context.Context, registry *registry) error
+}
+
+// Name returns the human-readable name of the entrypoint.
+func (e *Entrypoint) Name() string {
+	return e.name
+}
+
+// Source returns the source package path of the entrypoint.
+func (e *Entrypoint) Source() string {
+	return e.source
+}
+
+// apply applies the entrypoint option to the given registry.
+func (e *Entrypoint) apply(ctx context.Context, registry *registry) error {
+	return e.fn(ctx, registry)
 }

--- a/container.go
+++ b/container.go
@@ -92,7 +92,7 @@ type Option interface {
 //	gontainer.NewFactory(func(db *Database) (*Handler, error) { ... })
 //	gontainer.NewFactory(func(db *Database) (*Handler, func() error) { ... })
 //	gontainer.NewFactory(func(db *Database) (*Handler, func() error, error) { ... })
-func NewFactory(function any) *Factory {
+func NewFactory(function any, opts ...FactoryOption) *Factory {
 	funcValue := reflect.ValueOf(function)
 	funcType := reflect.TypeOf(function)
 
@@ -100,11 +100,18 @@ func NewFactory(function any) *Factory {
 	name := fmt.Sprintf("Factory[%s]", funcValue.Type())
 	source := getFuncSource(funcValue)
 
-	// Prepare option callback.
+	// Prepare factory settings.
+	settings := factorySettings{metadata: make(map[any]any)}
+	for _, opt := range opts {
+		opt.applyFactorySettings(&settings)
+	}
+
+	// Prepare factory instance.
 	return &Factory{
-		name:   name,
-		source: source,
-		fn: func(ctx context.Context, registry *registry) error {
+		name:     name,
+		source:   source,
+		metadata: settings.metadata,
+		register: func(ctx context.Context, registry *registry) error {
 			// Validate function type.
 			if funcType.Kind() != reflect.Func {
 				return fmt.Errorf("invalid type: %s", funcType)
@@ -177,7 +184,7 @@ func NewFactory(function any) *Factory {
 //
 //	logger := NewLogger()
 //	gontainer.NewService(logger)
-func NewService[T any](service T) *Factory {
+func NewService[T any](service T, opts ...FactoryOption) *Factory {
 	function := func() T { return service }
 	funcValue := reflect.ValueOf(function)
 	funcType := reflect.TypeOf(function)
@@ -187,11 +194,18 @@ func NewService[T any](service T) *Factory {
 	name := fmt.Sprintf("Service[%s]", serviceType)
 	source := serviceType.PkgPath()
 
-	// Prepare option callback.
+	// Prepare factory settings.
+	settings := factorySettings{metadata: make(map[any]any)}
+	for _, opt := range opts {
+		opt.applyFactorySettings(&settings)
+	}
+
+	// Prepare factory instance.
 	return &Factory{
-		name:   name,
-		source: source,
-		fn: func(ctx context.Context, registry *registry) error {
+		name:     name,
+		source:   source,
+		metadata: settings.metadata,
+		register: func(ctx context.Context, registry *registry) error {
 			// Prepare value and error getters.
 			getOutType := func(outTypes []reflect.Type) reflect.Type { return funcType.Out(0) }
 			getOutValue := func(outValues []reflect.Value) reflect.Value { return outValues[0] }
@@ -213,11 +227,18 @@ func NewService[T any](service T) *Factory {
 	}
 }
 
+// FactoryOption is an option for configuring a Factory or a Service.
+type FactoryOption interface {
+	// applyFactorySettings applies the metadata option to the factory settings.
+	applyFactorySettings(*factorySettings)
+}
+
 // Factory is a container option that registers a service factory or singleton.
 type Factory struct {
-	name   string
-	source string
-	fn     func(ctx context.Context, registry *registry) error
+	name     string
+	source   string
+	metadata map[any]any
+	register func(ctx context.Context, registry *registry) error
 }
 
 // Name returns the human-readable name of the factory.
@@ -230,9 +251,24 @@ func (f *Factory) Source() string {
 	return f.source
 }
 
+// Metadata returns the associated factory metadata.
+func (f *Factory) Metadata() map[any]any {
+	return f.metadata
+}
+
 // apply applies the factory option to the given registry.
 func (f *Factory) apply(ctx context.Context, registry *registry) error {
-	return f.fn(ctx, registry)
+	return f.register(ctx, registry)
+}
+
+// factorySettings holds configuration options applied to a Factory or Service.
+type factorySettings struct {
+	metadata map[any]any
+}
+
+// setMetadata sets metadata key-value pair.
+func (s *factorySettings) setMetadata(key any, value any) {
+	s.metadata[key] = value
 }
 
 // NewEntrypoint creates a new factory which will be called by the container.
@@ -241,19 +277,26 @@ func (f *Factory) apply(ctx context.Context, registry *registry) error {
 //
 //	gontainer.NewEntrypoint(func(db *Database) error { ... })
 //	gontainer.NewEntrypoint(func(db *Database) { ... })
-func NewEntrypoint(function any) *Entrypoint {
+func NewEntrypoint(function any, opts ...EntrypointOption) *Entrypoint {
 	funcValue := reflect.ValueOf(function)
 	funcType := reflect.TypeOf(function)
 
-	// Prepare factory description.
+	// Prepare entrypoint description.
 	name := fmt.Sprintf("Entrypoint[%s]", funcValue.Type())
 	source := getFuncSource(funcValue)
 
-	// Prepare option callback.
+	// Prepare entrypoint settings.
+	settings := entrypointSettings{metadata: make(map[any]any)}
+	for _, opt := range opts {
+		opt.applyEntrypointSettings(&settings)
+	}
+
+	// Prepare entrypoint instance.
 	return &Entrypoint{
-		name:   name,
-		source: source,
-		fn: func(ctx context.Context, registry *registry) error {
+		name:     name,
+		source:   source,
+		metadata: settings.metadata,
+		register: func(ctx context.Context, registry *registry) error {
 			// Validate function type.
 			if funcType.Kind() != reflect.Func {
 				return fmt.Errorf("invalid type: %s", funcType)
@@ -301,11 +344,18 @@ func NewEntrypoint(function any) *Entrypoint {
 	}
 }
 
+// EntrypointOption is an option for configuring an Entrypoint.
+type EntrypointOption interface {
+	// applyEntrypointSettings applies the metadata option to the entrypoint settings.
+	applyEntrypointSettings(*entrypointSettings)
+}
+
 // Entrypoint is a container option that registers an entrypoint function.
 type Entrypoint struct {
-	name   string
-	source string
-	fn     func(ctx context.Context, registry *registry) error
+	name     string
+	source   string
+	metadata map[any]any
+	register func(ctx context.Context, registry *registry) error
 }
 
 // Name returns the human-readable name of the entrypoint.
@@ -318,7 +368,43 @@ func (e *Entrypoint) Source() string {
 	return e.source
 }
 
+// Metadata returns the associated entrypoint metadata.
+func (e *Entrypoint) Metadata() map[any]any {
+	return e.metadata
+}
+
 // apply applies the entrypoint option to the given registry.
 func (e *Entrypoint) apply(ctx context.Context, registry *registry) error {
-	return e.fn(ctx, registry)
+	return e.register(ctx, registry)
+}
+
+// entrypointSettings holds configuration options applied to an Entrypoint.
+type entrypointSettings struct {
+	metadata map[any]any
+}
+
+// setMetadata sets metadata key-value pair.
+func (s *entrypointSettings) setMetadata(key any, value any) {
+	s.metadata[key] = value
+}
+
+// WithMetadata returns an option that attaches a key-value pair.
+func WithMetadata(key, value any) metadataOpt {
+	return metadataOpt{key: key, value: value}
+}
+
+// metadataOpt is a key-value pair attachable to a Factory or Entrypoint.
+type metadataOpt struct {
+	key   any
+	value any
+}
+
+// applyFactorySettings applies the metadata option to the factory settings.
+func (m metadataOpt) applyFactorySettings(s *factorySettings) {
+	s.setMetadata(m.key, m.value)
+}
+
+// applyEntrypointSettings applies the metadata option to the entrypoint settings.
+func (m metadataOpt) applyEntrypointSettings(s *entrypointSettings) {
+	s.setMetadata(m.key, m.value)
 }

--- a/container.go
+++ b/container.go
@@ -20,6 +20,7 @@ package gontainer
 import (
 	"context"
 	"fmt"
+	"maps"
 	"reflect"
 )
 
@@ -253,7 +254,7 @@ func (f *Factory) Source() string {
 
 // Metadata returns the associated factory metadata.
 func (f *Factory) Metadata() map[any]any {
-	return f.metadata
+	return maps.Clone(f.metadata)
 }
 
 // apply applies the factory option to the given registry.
@@ -370,7 +371,7 @@ func (e *Entrypoint) Source() string {
 
 // Metadata returns the associated entrypoint metadata.
 func (e *Entrypoint) Metadata() map[any]any {
-	return e.metadata
+	return maps.Clone(e.metadata)
 }
 
 // apply applies the entrypoint option to the given registry.

--- a/container.go
+++ b/container.go
@@ -20,8 +20,8 @@ package gontainer
 import (
 	"context"
 	"fmt"
-	"maps"
 	"reflect"
+	"slices"
 )
 
 // Run runs a container with a set of configured factories.
@@ -102,16 +102,16 @@ func NewFactory(function any, opts ...FactoryOption) *Factory {
 	source := getFuncSource(funcValue)
 
 	// Prepare factory settings.
-	settings := factorySettings{metadata: make(map[any]any)}
+	settings := factorySettings{}
 	for _, opt := range opts {
-		opt.applyFactorySettings(&settings)
+		opt.applyFactory(&settings)
 	}
 
 	// Prepare factory instance.
 	return &Factory{
-		name:     name,
-		source:   source,
-		metadata: settings.metadata,
+		name:        name,
+		source:      source,
+		annotations: settings.annotations,
 		register: func(ctx context.Context, registry *registry) error {
 			// Validate function type.
 			if funcType.Kind() != reflect.Func {
@@ -196,16 +196,16 @@ func NewService[T any](service T, opts ...FactoryOption) *Factory {
 	source := serviceType.PkgPath()
 
 	// Prepare factory settings.
-	settings := factorySettings{metadata: make(map[any]any)}
+	settings := factorySettings{}
 	for _, opt := range opts {
-		opt.applyFactorySettings(&settings)
+		opt.applyFactory(&settings)
 	}
 
 	// Prepare factory instance.
 	return &Factory{
-		name:     name,
-		source:   source,
-		metadata: settings.metadata,
+		name:        name,
+		source:      source,
+		annotations: settings.annotations,
 		register: func(ctx context.Context, registry *registry) error {
 			// Prepare value and error getters.
 			getOutType := func(outTypes []reflect.Type) reflect.Type { return funcType.Out(0) }
@@ -230,16 +230,16 @@ func NewService[T any](service T, opts ...FactoryOption) *Factory {
 
 // FactoryOption is an option for configuring a Factory or a Service.
 type FactoryOption interface {
-	// applyFactorySettings applies the metadata option to the factory settings.
-	applyFactorySettings(*factorySettings)
+	// applyFactory applies the option to the factory settings.
+	applyFactory(*factorySettings)
 }
 
 // Factory is a container option that registers a service factory or singleton.
 type Factory struct {
-	name     string
-	source   string
-	metadata map[any]any
-	register func(ctx context.Context, registry *registry) error
+	name        string
+	source      string
+	annotations []any
+	register    func(ctx context.Context, registry *registry) error
 }
 
 // Name returns the human-readable name of the factory.
@@ -252,9 +252,9 @@ func (f *Factory) Source() string {
 	return f.source
 }
 
-// Metadata returns the associated factory metadata.
-func (f *Factory) Metadata() map[any]any {
-	return maps.Clone(f.metadata)
+// Annotations returns a copy of the associated annotations.
+func (f *Factory) Annotations() []any {
+	return slices.Clone(f.annotations)
 }
 
 // apply applies the factory option to the given registry.
@@ -264,12 +264,12 @@ func (f *Factory) apply(ctx context.Context, registry *registry) error {
 
 // factorySettings holds configuration options applied to a Factory or Service.
 type factorySettings struct {
-	metadata map[any]any
+	annotations []any
 }
 
-// setMetadata sets metadata key-value pair.
-func (s *factorySettings) setMetadata(key any, value any) {
-	s.metadata[key] = value
+// appendAnnotation appends an annotation value.
+func (s *factorySettings) appendAnnotation(value any) {
+	s.annotations = append(s.annotations, value)
 }
 
 // NewEntrypoint creates a new factory which will be called by the container.
@@ -287,16 +287,16 @@ func NewEntrypoint(function any, opts ...EntrypointOption) *Entrypoint {
 	source := getFuncSource(funcValue)
 
 	// Prepare entrypoint settings.
-	settings := entrypointSettings{metadata: make(map[any]any)}
+	settings := entrypointSettings{}
 	for _, opt := range opts {
-		opt.applyEntrypointSettings(&settings)
+		opt.applyEntrypoint(&settings)
 	}
 
 	// Prepare entrypoint instance.
 	return &Entrypoint{
-		name:     name,
-		source:   source,
-		metadata: settings.metadata,
+		name:        name,
+		source:      source,
+		annotations: settings.annotations,
 		register: func(ctx context.Context, registry *registry) error {
 			// Validate function type.
 			if funcType.Kind() != reflect.Func {
@@ -347,16 +347,16 @@ func NewEntrypoint(function any, opts ...EntrypointOption) *Entrypoint {
 
 // EntrypointOption is an option for configuring an Entrypoint.
 type EntrypointOption interface {
-	// applyEntrypointSettings applies the metadata option to the entrypoint settings.
-	applyEntrypointSettings(*entrypointSettings)
+	// applyEntrypoint applies the option to the entrypoint settings.
+	applyEntrypoint(*entrypointSettings)
 }
 
 // Entrypoint is a container option that registers an entrypoint function.
 type Entrypoint struct {
-	name     string
-	source   string
-	metadata map[any]any
-	register func(ctx context.Context, registry *registry) error
+	name        string
+	source      string
+	annotations []any
+	register    func(ctx context.Context, registry *registry) error
 }
 
 // Name returns the human-readable name of the entrypoint.
@@ -369,9 +369,9 @@ func (e *Entrypoint) Source() string {
 	return e.source
 }
 
-// Metadata returns the associated entrypoint metadata.
-func (e *Entrypoint) Metadata() map[any]any {
-	return maps.Clone(e.metadata)
+// Annotations returns a copy of the associated annotations.
+func (e *Entrypoint) Annotations() []any {
+	return slices.Clone(e.annotations)
 }
 
 // apply applies the entrypoint option to the given registry.
@@ -381,31 +381,30 @@ func (e *Entrypoint) apply(ctx context.Context, registry *registry) error {
 
 // entrypointSettings holds configuration options applied to an Entrypoint.
 type entrypointSettings struct {
-	metadata map[any]any
+	annotations []any
 }
 
-// setMetadata sets metadata key-value pair.
-func (s *entrypointSettings) setMetadata(key any, value any) {
-	s.metadata[key] = value
+// appendAnnotation appends an annotation value.
+func (s *entrypointSettings) appendAnnotation(value any) {
+	s.annotations = append(s.annotations, value)
 }
 
-// WithMetadata returns an option that attaches a key-value pair.
-func WithMetadata(key, value any) metadataOpt {
-	return metadataOpt{key: key, value: value}
+// WithAnnotation returns an option that attaches a value to a Factory or Entrypoint.
+func WithAnnotation(value any) annotationOpt {
+	return annotationOpt{value: value}
 }
 
-// metadataOpt is a key-value pair attachable to a Factory or Entrypoint.
-type metadataOpt struct {
-	key   any
+// annotationOpt is a value attachable to a Factory or Entrypoint.
+type annotationOpt struct {
 	value any
 }
 
-// applyFactorySettings applies the metadata option to the factory settings.
-func (m metadataOpt) applyFactorySettings(s *factorySettings) {
-	s.setMetadata(m.key, m.value)
+// applyFactorySettings applies the option to the factory settings.
+func (m annotationOpt) applyFactory(s *factorySettings) {
+	s.appendAnnotation(m.value)
 }
 
-// applyEntrypointSettings applies the metadata option to the entrypoint settings.
-func (m metadataOpt) applyEntrypointSettings(s *entrypointSettings) {
-	s.setMetadata(m.key, m.value)
+// applyEntrypointSettings applies the option to the entrypoint settings.
+func (m annotationOpt) applyEntrypoint(s *entrypointSettings) {
+	s.appendAnnotation(m.value)
 }

--- a/registry_test.go
+++ b/registry_test.go
@@ -47,12 +47,12 @@ func TestRegistryRegisterFactory(t *testing.T) {
 func TestRegistryValidateFactories(t *testing.T) {
 	tests := []struct {
 		name    string
-		options []option
+		options []Option
 		wantErr func(t *testing.T, err error)
 	}{
 		{
 			name: "NoValidationErrors",
-			options: []option{
+			options: []Option{
 				NewFactory(func(bool) (int, error) { return 1, nil }),
 				NewFactory(func(string) (bool, error) { return true, nil }),
 				NewFactory(func() (string, error) { return "s", nil }),
@@ -64,7 +64,7 @@ func TestRegistryValidateFactories(t *testing.T) {
 		},
 		{
 			name: "ServiceNotResolvedError",
-			options: []option{
+			options: []Option{
 				NewFactory(func(bool) (int, error) { return 0, nil }),
 				NewFactory(func(string) (int32, error) { return 0, nil }),
 				NewEntrypoint(func(int, int32) {}),
@@ -90,7 +90,7 @@ func TestRegistryValidateFactories(t *testing.T) {
 		},
 		{
 			name: "ServiceDuplicatedError",
-			options: []option{
+			options: []Option{
 				NewFactory(func() (string, error) { return "s1", nil }),
 				NewFactory(func() (string, error) { return "s2", nil }),
 				NewEntrypoint(func(string) {}),
@@ -116,7 +116,7 @@ func TestRegistryValidateFactories(t *testing.T) {
 		},
 		{
 			name: "CircularDependencyErrors",
-			options: []option{
+			options: []Option{
 				NewFactory(func(bool) (int, error) { return 1, nil }),
 				NewFactory(func(string) (bool, error) { return true, nil }),
 				NewFactory(func(int) (string, error) { return "s", nil }),
@@ -148,7 +148,7 @@ func TestRegistryValidateFactories(t *testing.T) {
 		},
 		{
 			name: "ComplexErrors",
-			options: []option{
+			options: []Option{
 				NewFactory(func(struct{ X int }) string { return "s1" }),                   // not resolved, duplicate
 				NewFactory(func(ctx context.Context) (string, error) { return "s2", nil }), // duplicate
 				NewFactory(func(bool) (int, error) { return 1, nil }),                      // cycle
@@ -271,7 +271,7 @@ func TestRegistryResolveFuncServices(t *testing.T) {
 	func2Calls := atomic.Int64{}
 	fact3Calls := atomic.Int64{}
 
-	options := []option{
+	options := []Option{
 		NewFactory(func() func() int {
 			return func() int {
 				func1Calls.Add(1)


### PR DESCRIPTION
### API Refactoring and Extensibility

* Renamed the internal `option` interface to the exported `Option` interface, making it part of the public API and updating all references accordingly.
* Reworked the `Factory` and `Entrypoint` types to support named options (`FactoryOption`, `EntrypointOption`) and metadata, and to expose their name, source, and metadata via new methods.
* Added the `WithMetadata` option, allowing users to attach arbitrary key-value metadata to factories and entrypoints.