### PR TITLE
Enhance README and refactor Optional and Multiple types

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,43 @@ gontainer.NewEntrypoint(func(newTx func() *Transaction) {
 })
 ```
 
+### Factory Annotations
+
+Attach arbitrary metadata to a factory or entrypoint with `WithAnnotation`.
+Annotations are exposed via `Factory.Annotations()` / `Entrypoint.Annotations()`
+and can be read **without starting the container** - useful for `--help`,
+config validation, CLI dispatch, or any pre-run tooling built on top of the
+same factory definitions.
+
+```go
+type cliHelp struct {
+    Cmd string
+    Doc string
+}
+
+configFactory := gontainer.NewFactory(
+    newConfig,
+    gontainer.WithAnnotation(cliHelp{Cmd: "config", Doc: "Print resolved config"}),
+)
+
+dbFactory := gontainer.NewFactory(
+    newDatabase,
+    gontainer.WithAnnotation(cliHelp{Cmd: "db", Doc: "Ping the database"}),
+)
+
+// Inspect annotations without starting the container.
+for _, f := range []*gontainer.Factory{configFactory, dbFactory} {
+    for _, a := range f.Annotations() {
+        if h, ok := a.(cliHelp); ok {
+            fmt.Printf("%s\t%s\n", h.Cmd, h.Doc)
+        }
+    }
+}
+
+// Start the container with the same factories when ready.
+_ = gontainer.Run(ctx, configFactory, dbFactory, entrypoint)
+```
+
 ## API Reference
 
 ### Module Functions

--- a/README.md
+++ b/README.md
@@ -361,15 +361,20 @@ func(invoker *gontainer.Invoker) *Service
 
 ### Special Types
 
-Gontainer provides special types for optional and multiple dependencies.
+Gontainer provides special types for declaring optional and multiple
+dependencies in factory and entrypoint signatures. See
+[Optional Dependencies](#optional-dependencies) and
+[Multiple Dependencies](#multiple-dependencies) for full examples.
 
 ```go
-// Optional[T] - Optional dependency declaration.
-type Optional[T any] struct{}
-func (o Optional[T]) Get() T
+// Optional[T] - declares a dependency that may be absent from the container.
+// Call .Get() to read the value; the zero value of T is returned when no
+// matching factory is registered.
+func(logger gontainer.Optional[*Logger]) *Service
 
-// Multiple[T] - Multiple services of the same interface.
-type Multiple[T any] []T
+// Multiple[T] - declares a dependency on all services assignable to T.
+// Range over the slice to access each registered service.
+func(providers gontainer.Multiple[AuthProvider]) *Router
 ```
 
 ## Error Handling

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/NVIDIA/gontainer/v2
 
 go 1.21
+
+toolchain go1.23.0

--- a/invoker.go
+++ b/invoker.go
@@ -46,8 +46,8 @@ func (i *Invoker) Invoke(function any) ([]any, error) {
 	// Get reflection of the function.
 	funcValue := reflect.ValueOf(function)
 	funcType := reflect.TypeOf(function)
-	if funcType.Kind() != reflect.Func {
-		return nil, fmt.Errorf("invalid type: %s", funcType)
+	if funcType == nil || funcType.Kind() != reflect.Func {
+		return nil, fmt.Errorf("invalid type: %v", funcType)
 	}
 
 	// Resolve function arguments.

--- a/invoker_test.go
+++ b/invoker_test.go
@@ -89,6 +89,18 @@ func TestInvokerService(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name:    "InvokeNilReturnsError",
+			haveFn:  nil,
+			wantFn:  nil,
+			wantErr: true,
+		},
+		{
+			name:    "InvokeNonFuncReturnsError",
+			haveFn:  42,
+			wantFn:  nil,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/multiple.go
+++ b/multiple.go
@@ -19,6 +19,7 @@ package gontainer
 
 import (
 	"reflect"
+	"strings"
 )
 
 // Multiple defines a dependency on zero or more services of the same type.
@@ -39,20 +40,31 @@ import (
 //	}
 type Multiple[T any] []T
 
-// Multiple marks this type as multiple.
-func (m Multiple[T]) Multiple() {}
-
-// isMultipleType checks and returns optional box type.
+// isMultipleType checks and returns multiple box type.
 func isMultipleType(typ reflect.Type) (reflect.Type, bool) {
-	if typ.Kind() == reflect.Slice {
-		if _, ok := typ.MethodByName("Multiple"); ok {
-			return typ.Elem(), true
-		}
+	// Check if the type is a slice.
+	if typ.Kind() != reflect.Slice {
+		return nil, false
 	}
-	return nil, false
+
+	// Check if the type is a Multiple type.
+	sample := reflect.TypeOf(Multiple[struct{}]{})
+	if typ.PkgPath() != sample.PkgPath() {
+		return nil, false
+	}
+
+	// Check if the type is a Multiple type.
+	sampleName := sample.Name()
+	sep := strings.IndexByte(sampleName, '[')
+	if sep < 0 || !strings.HasPrefix(typ.Name(), sampleName[:sep+1]) {
+		return nil, false
+	}
+
+	// Return the element type of the slice.
+	return typ.Elem(), true
 }
 
-// newOptionalValue boxes an optional factory input to structs.
+// newMultipleValue packs multiple values to the slice.
 func newMultipleValue(typ reflect.Type, values []reflect.Value) reflect.Value {
 	box := reflect.New(typ).Elem()
 	return reflect.Append(box, values...)

--- a/optional.go
+++ b/optional.go
@@ -39,16 +39,23 @@ import (
 //	}
 type Optional[T any] struct {
 	value T
+	ok    bool
 }
 
-// Get returns optional service instance.
+// Get returns the optional service instance.
 func (o *Optional[T]) Get() T {
 	return o.value
+}
+
+// Ok reports whether the optional service was provided by the container.
+func (o *Optional[T]) Ok() bool {
+	return o.ok
 }
 
 // setValue populates the private value field.
 func (o *Optional[T]) setValue(v reflect.Value) {
 	reflect.ValueOf(&o.value).Elem().Set(v)
+	o.ok = true
 }
 
 // isOptionalType checks and returns optional box type.

--- a/optional.go
+++ b/optional.go
@@ -98,3 +98,8 @@ func newOptionalValue(typ reflect.Type, value reflect.Value) reflect.Value {
 
 	return ptr.Elem()
 }
+
+// newOptionalZero creates a new optional type with no value and ok set to false.
+func newOptionalZero(typ reflect.Type) reflect.Value {
+	return reflect.New(typ).Elem()
+}

--- a/optional.go
+++ b/optional.go
@@ -19,7 +19,6 @@ package gontainer
 
 import (
 	"reflect"
-	"unsafe"
 )
 
 // Optional defines a dependency on a service that may or may not be registered.
@@ -42,22 +41,29 @@ type Optional[T any] struct {
 }
 
 // Get returns optional service instance.
-func (o Optional[T]) Get() T {
+func (o *Optional[T]) Get() T {
 	return o.value
 }
 
 // Optional marks this type as optional.
-func (o Optional[T]) Optional() {}
+func (o *Optional[T]) Optional() {}
+
+// setValue populates the private value field.
+func (o *Optional[T]) setValue(v reflect.Value) {
+	reflect.ValueOf(&o.value).Elem().Set(v)
+}
 
 // isOptionalType checks and returns optional box type.
 func isOptionalType(typ reflect.Type) (reflect.Type, bool) {
-	if typ.Kind() == reflect.Struct {
-		if _, ok := typ.MethodByName("Optional"); ok {
-			if methodValue, ok := typ.MethodByName("Get"); ok {
-				if methodValue.Type.NumOut() == 1 {
-					methodType := methodValue.Type.Out(0)
-					return methodType, true
-				}
+	if typ.Kind() != reflect.Struct {
+		return nil, false
+	}
+	pointerType := reflect.PointerTo(typ)
+	if _, ok := pointerType.MethodByName("Optional"); ok {
+		if methodValue, ok := pointerType.MethodByName("Get"); ok {
+			if methodValue.Type.NumOut() == 1 {
+				methodType := methodValue.Type.Out(0)
+				return methodType, true
 			}
 		}
 	}
@@ -66,14 +72,11 @@ func isOptionalType(typ reflect.Type) (reflect.Type, bool) {
 
 // newOptionalValue creates new optional type with a value.
 func newOptionalValue(typ reflect.Type, value reflect.Value) reflect.Value {
-	// Prepare boxing struct for value.
-	box := reflect.New(typ).Elem()
+	// Allocate an addressable pointer to a zero Optional[T].
+	ptr := reflect.New(typ)
 
-	// Inject factory output value to the boxing struct.
-	field := box.FieldByName("value")
-	pointer := unsafe.Pointer(field.UnsafeAddr())
-	public := reflect.NewAt(field.Type(), pointer)
-	public.Elem().Set(value)
+	// Populate the private field via the internal setter interface.
+	ptr.Interface().(interface{ setValue(reflect.Value) }).setValue(value)
 
-	return box
+	return ptr.Elem()
 }

--- a/optional.go
+++ b/optional.go
@@ -19,6 +19,7 @@ package gontainer
 
 import (
 	"reflect"
+	"strings"
 )
 
 // Optional defines a dependency on a service that may or may not be registered.
@@ -45,9 +46,6 @@ func (o *Optional[T]) Get() T {
 	return o.value
 }
 
-// Optional marks this type as optional.
-func (o *Optional[T]) Optional() {}
-
 // setValue populates the private value field.
 func (o *Optional[T]) setValue(v reflect.Value) {
 	reflect.ValueOf(&o.value).Elem().Set(v)
@@ -55,19 +53,32 @@ func (o *Optional[T]) setValue(v reflect.Value) {
 
 // isOptionalType checks and returns optional box type.
 func isOptionalType(typ reflect.Type) (reflect.Type, bool) {
+	// Check if the type is a struct.
 	if typ.Kind() != reflect.Struct {
 		return nil, false
 	}
-	pointerType := reflect.PointerTo(typ)
-	if _, ok := pointerType.MethodByName("Optional"); ok {
-		if methodValue, ok := pointerType.MethodByName("Get"); ok {
-			if methodValue.Type.NumOut() == 1 {
-				methodType := methodValue.Type.Out(0)
-				return methodType, true
-			}
-		}
+
+	// Check if the type is a Optional type.
+	sample := reflect.TypeOf(Optional[struct{}]{})
+	if typ.PkgPath() != sample.PkgPath() {
+		return nil, false
 	}
-	return nil, false
+
+	// Check if the type is a Optional type.
+	sampleName := sample.Name()
+	sep := strings.IndexByte(sampleName, '[')
+	if sep < 0 || !strings.HasPrefix(typ.Name(), sampleName[:sep+1]) {
+		return nil, false
+	}
+
+	// Check if the type has a value field.
+	field, ok := typ.FieldByName("value")
+	if !ok {
+		return nil, false
+	}
+
+	// Return the type of the value field.
+	return field.Type, true
 }
 
 // newOptionalValue creates new optional type with a value.

--- a/optional_test.go
+++ b/optional_test.go
@@ -50,11 +50,13 @@ func TestNewOptionalValue(t *testing.T) {
 	box := Optional[string]{}
 	data := reflect.New(reflect.TypeOf((*string)(nil)).Elem()).Elem()
 	value := newOptionalValue(reflect.TypeOf(box), data)
-	equal(t, value.Interface().(Optional[string]).Get(), "")
+	opt := value.Interface().(Optional[string])
+	equal(t, opt.Get(), "")
 
 	// When optional found.
 	box = Optional[string]{}
 	data = reflect.ValueOf("result")
 	value = newOptionalValue(reflect.TypeOf(box), data)
-	equal(t, value.Interface().(Optional[string]).Get(), "result")
+	opt = value.Interface().(Optional[string])
+	equal(t, opt.Get(), "result")
 }

--- a/optional_test.go
+++ b/optional_test.go
@@ -60,3 +60,29 @@ func TestNewOptionalValue(t *testing.T) {
 	opt = value.Interface().(Optional[string])
 	equal(t, opt.Get(), "result")
 }
+
+// TestOptionalOkNotProvided tests that Ok returns false when the service is not provided.
+func TestOptionalOkNotProvided(t *testing.T) {
+	typ := reflect.TypeOf(Optional[string]{})
+	value := newOptionalZero(typ)
+	opt := value.Interface().(Optional[string])
+	if opt.Ok() {
+		t.Errorf("expected Ok() to return false for zero optional, got true")
+	}
+	if opt.Get() != "" {
+		t.Errorf("expected Get() to return zero value, got %q", opt.Get())
+	}
+}
+
+// TestOptionalOkProvided tests that Ok returns true when the service is provided.
+func TestOptionalOkProvided(t *testing.T) {
+	typ := reflect.TypeOf(Optional[string]{})
+	value := newOptionalValue(typ, reflect.ValueOf("hello"))
+	opt := value.Interface().(Optional[string])
+	if !opt.Ok() {
+		t.Errorf("expected Ok() to return true for provided optional, got false")
+	}
+	if opt.Get() != "hello" {
+		t.Errorf("expected Get() to return %q, got %q", "hello", opt.Get())
+	}
+}

--- a/registry.go
+++ b/registry.go
@@ -332,15 +332,22 @@ func (r *registry) findFactories(serviceType reflect.Type) []*factory {
 
 	// Lookup for factories in the registry.
 	for _, factory := range r.factories {
+		outType := factory.getOutType()
+
+		// Skip factories without an output type.
+		if outType == nil {
+			continue
+		}
+
 		// Desired service type matched.
-		if factory.getOutType() == serviceType {
+		if outType == serviceType {
 			factories = append(factories, factory)
 			continue
 		}
 
 		// Desired service type implements an interface.
 		if serviceType.Kind() == reflect.Interface {
-			if factory.getOutType().Implements(serviceType) {
+			if outType.Implements(serviceType) {
 				factories = append(factories, factory)
 				continue
 			}

--- a/registry.go
+++ b/registry.go
@@ -254,8 +254,7 @@ func (r *registry) resolveOptional(optionalType, serviceType reflect.Type) (refl
 	// unregistered type `Config` triggers an error, while resolving `gontainer.Optional[Config]`
 	// returns a zero-value box.
 	if len(serviceValues) == 0 {
-		zeroValue := reflect.New(serviceType).Elem()
-		return newOptionalValue(optionalType, zeroValue), nil
+		return newOptionalZero(optionalType), nil
 	}
 
 	// Return resolved service in an optional box type.


### PR DESCRIPTION
This pull request introduces several improvements to the handling of optional and multiple dependencies. The changes make the detection of `Optional` and `Multiple` types more robust, simplify internal reflection logic, and clarify documentation. There are also enhancements to error handling and test coverage. Below are the most important changes grouped by theme:

### Optional and Multiple Dependency Handling

* Refactored the detection of `Optional` and `Multiple` types to use more robust reflection-based checks, removing reliance on marker methods and improving type safety. This includes checking the package path and generic type name, and directly inspecting struct fields (`optional.go`, `multiple.go`). [[1]](diffhunk://#diff-546e478e4f610194dc696014fcc8754ed3fc5d533ea7cf9864a69bb4d5e8f703L45-R92) [[2]](diffhunk://#diff-f36ab09e5c7aff52cf58ff49edde423e0b2540f3e0583510f26e1d0a58634b72L42-R67)
* Updated the implementation of `Optional[T].Get()` to use a pointer receiver, and introduced an unexported `setValue` method for internal population of the value field via reflection (`optional.go`).
* Updated the implementation of `newOptionalValue` and `newMultipleValue` to use the new type detection and value setting mechanisms, improving encapsulation and correctness (`optional.go`, `multiple.go`). [[1]](diffhunk://#diff-546e478e4f610194dc696014fcc8754ed3fc5d533ea7cf9864a69bb4d5e8f703L45-R92) [[2]](diffhunk://#diff-f36ab09e5c7aff52cf58ff49edde423e0b2540f3e0583510f26e1d0a58634b72L42-R67)

### Documentation Improvements

* Expanded the README with a new section on factory annotations, showing how to attach and inspect arbitrary metadata for use in CLI and tooling scenarios (`README.md`).
* Clarified documentation for `Optional` and `Multiple` types, providing concise explanations and usage examples in the README (`README.md`).

### Error Handling and Test Coverage

* Improved error handling in the `Invoker.Invoke` method to correctly handle `nil` and non-function arguments, and updated tests to cover these cases (`invoker.go`, `invoker_test.go`). [[1]](diffhunk://#diff-64f7828f1129f7091326ab7f73d52b42d1f2197c614016f66bcd8573ecdb40feL49-R50) [[2]](diffhunk://#diff-b94afd8f2b61900f3e2589c5034cde0e920eed8942b19ad5f58c119e4f40503bR92-R103)
* Fixed a bug in the registry where factories without an output type could cause panics, by adding a nil check before type comparisons (`registry.go`).

### Miscellaneous

* Added `strings` import to relevant files to support the new reflection logic (`optional.go`, `multiple.go`). [[1]](diffhunk://#diff-546e478e4f610194dc696014fcc8754ed3fc5d533ea7cf9864a69bb4d5e8f703L22-R22) [[2]](diffhunk://#diff-f36ab09e5c7aff52cf58ff49edde423e0b2540f3e0583510f26e1d0a58634b72R22)
* Updated the Go toolchain version in `go.mod` to `go1.23.0` (`go.mod`).