### PR TITLE
Rid of legacy context-based termination flow based on V1 patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,60 @@ gontainer.NewFactory(func(middlewares gontainer.Multiple[Middleware]) *Router {
 })
 ```
 
+### Multiple Instances of the Same Type
+
+The container matches services by exact type. To register several instances
+of the same underlying type, give each one a distinct named type (compile-time)
+or group them in a composite service (runtime):
+
+```go
+// Compile-time: the set of instances is known at build time.
+// Typos and wiring mistakes are caught by the compiler.
+type UsersDB  *sql.DB
+type OrdersDB *sql.DB
+
+gontainer.NewFactory(func(c *Config) (UsersDB, func() error) {
+    db, _ := sql.Open("postgres", c.UsersDSN)
+    return db, db.Close
+})
+
+gontainer.NewFactory(func(c *Config) (OrdersDB, func() error) {
+    db, _ := sql.Open("postgres", c.OrdersDSN)
+    return db, db.Close
+})
+
+gontainer.NewFactory(func(u UsersDB, o OrdersDB) *Service {
+    return &Service{users: u, orders: o}
+})
+```
+
+```go
+// Runtime: the set of instances comes from configuration.
+// Access is stringly-typed but flexible.
+type DBs struct{ byAlias map[string]*sql.DB }
+
+func (d *DBs) Get(alias string) *sql.DB { return d.byAlias[alias] }
+
+gontainer.NewFactory(func(c *Config) (*DBs, func() error) {
+    open := make(map[string]*sql.DB, len(c.Databases))
+    for alias, dsn := range c.Databases {
+        db, _ := sql.Open("postgres", dsn)
+        open[alias] = db
+    }
+    return &DBs{byAlias: open}, func() error {
+        var errs []error
+        for _, db := range open {
+            errs = append(errs, db.Close())
+        }
+        return errors.Join(errs...)
+    }
+})
+
+gontainer.NewFactory(func(dbs *DBs) *Service {
+    return &Service{users: dbs.Get("users")}
+})
+```
+
 ### Dynamic Resolution
 
 Resolve services on-demand:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ The example shows how to build the simplest app using service container.
 package main
 
 import (
-    "context"
     "log"
     "github.com/NVIDIA/gontainer/v2"
 )
@@ -37,8 +36,6 @@ type UserService struct{ db *Database }
 
 func main() {
     err := gontainer.Run(
-        context.Background(),
-        
         // Register Database.
         gontainer.NewFactory(func() *Database {
             return &Database{connString: "postgres://localhost/myapp"}
@@ -157,7 +154,6 @@ gontainer.NewFactory(func() (*Database, func() error) {
 
 ```go
 err := gontainer.Run(
-    context.Background(),
     gontainer.NewFactory(...),
     gontainer.NewFactory(...),
     gontainer.NewEntrypoint(func(/* dependencies */) {
@@ -293,7 +289,7 @@ for _, f := range []*gontainer.Factory{configFactory, dbFactory} {
 }
 
 // Start the container with the same factories when ready.
-_ = gontainer.Run(ctx, configFactory, dbFactory, entrypoint)
+_ = gontainer.Run(configFactory, dbFactory, entrypoint)
 ```
 
 ## API Reference
@@ -304,7 +300,7 @@ Gontainer module interface is really simple:
 
 ```go
 // Run creates and runs a container with provided factories and entrypoints.
-func Run(ctx context.Context, opts ...Option) error
+func Run(options ...Option) error
 
 // NewFactory registers a service factory.
 func NewFactory(fn any) *Factory
@@ -323,7 +319,7 @@ and can optionally return an error and/or a cleanup function for the factory.
 
 **Dependencies** are other services that the factory needs which are automatically injected.
 
-**Service** is a user-provided type. It can be any type except untyped `any`, context and `error`.
+**Service** is a user-provided type. It can be any type except untyped `any` and `error`.
 
 
 ```go
@@ -346,12 +342,9 @@ func() (*Service, func() error, error)
 ### Built-in Services
 
 Gontainer provides several built-in services that can be injected into factories and functions.
-They provide access to container features like context, dynamic resolution, and invocation.
+They provide access to container features like dynamic resolution and invocation.
 
 ```go
-// context.Context - The factory's context.
-func(ctx context.Context) *Service
-
 // *gontainer.Resolver - Dynamic service resolution.
 func(resolver *gontainer.Resolver) *Service
 
@@ -382,7 +375,7 @@ func(providers gontainer.Multiple[AuthProvider]) *Router
 Gontainer provides typed errors for different failure scenarios:
 
 ```go
-err := gontainer.Run(ctx, factories...)
+err := gontainer.Run(factories...)
 
 switch {
 case errors.Is(err, gontainer.ErrFactoryReturnedError):

--- a/container.go
+++ b/container.go
@@ -18,20 +18,18 @@
 package gontainer
 
 import (
-	"context"
 	"fmt"
 	"reflect"
 	"slices"
 )
 
 // Run runs a container with a set of configured factories.
-func Run(ctx context.Context, options ...Option) error {
-	// Prepare container context ignoring the cancelling.
-	// When cancelled, it closes `container.Done()` channel
-	// and unblocks any waiting read from `container.Done()`.
-	ctx, cancel := context.WithCancel(context.WithoutCancel(ctx))
-	defer cancel()
-
+//
+// Run registers the provided options, validates the registry, invokes
+// entrypoints synchronously, and then tears down all spawned factories
+// in reverse order. It returns when all entrypoints have returned and
+// teardown has completed.
+func Run(options ...Option) error {
 	// Prepare services registry instance.
 	registry := &registry{}
 
@@ -42,18 +40,18 @@ func Run(ctx context.Context, options ...Option) error {
 	invoker := &Invoker{registry: registry}
 
 	// Register service resolver instance in the registry.
-	if err := NewService(resolver).apply(ctx, registry); err != nil {
+	if err := NewService(resolver).apply(registry); err != nil {
 		return fmt.Errorf("failed to register resolver: %w", err)
 	}
 
 	// Register function invoker instance in the registry.
-	if err := NewService(invoker).apply(ctx, registry); err != nil {
+	if err := NewService(invoker).apply(registry); err != nil {
 		return fmt.Errorf("failed to register invoker: %w", err)
 	}
 
 	// Register provided factories in the registry.
 	for _, option := range options {
-		if err := option.apply(ctx, registry); err != nil {
+		if err := option.apply(registry); err != nil {
 			return fmt.Errorf("failed to apply option: %w", err)
 		}
 	}
@@ -79,7 +77,7 @@ func Run(ctx context.Context, options ...Option) error {
 
 // Option is the interface for container options.
 type Option interface {
-	apply(ctx context.Context, registry *registry) error
+	apply(registry *registry) error
 }
 
 // NewFactory creates a new service load using the provided load function.
@@ -112,7 +110,7 @@ func NewFactory(function any, opts ...FactoryOption) *Factory {
 		name:        name,
 		source:      source,
 		annotations: settings.annotations,
-		register: func(ctx context.Context, registry *registry) error {
+		register: func(registry *registry) error {
 			// Validate function type.
 			if funcType.Kind() != reflect.Func {
 				return fmt.Errorf("invalid type: %s", funcType)
@@ -127,28 +125,28 @@ func NewFactory(function any, opts ...FactoryOption) *Factory {
 			// Prepare value and error getters.
 			switch {
 			// Factory returns exactly one service.
-			case funcType.NumOut() == 1 && isUsefulService(funcType.Out(0)):
+			case funcType.NumOut() == 1 && !isEmptyInterface(funcType.Out(0)) && !isErrorInterface(funcType.Out(0)):
 				getOutType = func(outTypes []reflect.Type) reflect.Type { return outTypes[0] }
 				getOutValue = func(outValues []reflect.Value) reflect.Value { return outValues[0] }
 				getOutClose = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
 				getOutError = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
 
 			// Factory returns a service and an error.
-			case funcType.NumOut() == 2 && isUsefulService(funcType.Out(0)) && isErrorInterface(funcType.Out(1)):
+			case funcType.NumOut() == 2 && !isEmptyInterface(funcType.Out(0)) && !isErrorInterface(funcType.Out(0)) && isErrorInterface(funcType.Out(1)):
 				getOutType = func(outTypes []reflect.Type) reflect.Type { return outTypes[0] }
 				getOutValue = func(outValues []reflect.Value) reflect.Value { return outValues[0] }
 				getOutClose = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
 				getOutError = func(outValues []reflect.Value) reflect.Value { return outValues[1] }
 
 			// Factory returns a service and a close callback.
-			case funcType.NumOut() == 2 && isUsefulService(funcType.Out(0)) && isCloseCallback(funcType.Out(1)):
+			case funcType.NumOut() == 2 && !isEmptyInterface(funcType.Out(0)) && !isErrorInterface(funcType.Out(0)) && isCloseCallback(funcType.Out(1)):
 				getOutType = func(outTypes []reflect.Type) reflect.Type { return outTypes[0] }
 				getOutValue = func(outValues []reflect.Value) reflect.Value { return outValues[0] }
 				getOutClose = func(outValues []reflect.Value) reflect.Value { return outValues[1] }
 				getOutError = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
 
 			// Factory returns a service, a close callback and an error.
-			case funcType.NumOut() == 3 && isUsefulService(funcType.Out(0)) && isCloseCallback(funcType.Out(1)) && isErrorInterface(funcType.Out(2)):
+			case funcType.NumOut() == 3 && !isEmptyInterface(funcType.Out(0)) && !isErrorInterface(funcType.Out(0)) && isCloseCallback(funcType.Out(1)) && isErrorInterface(funcType.Out(2)):
 				getOutType = func(outTypes []reflect.Type) reflect.Type { return outTypes[0] }
 				getOutValue = func(outValues []reflect.Value) reflect.Value { return outValues[0] }
 				getOutClose = func(outValues []reflect.Value) reflect.Value { return outValues[1] }
@@ -160,7 +158,7 @@ func NewFactory(function any, opts ...FactoryOption) *Factory {
 			}
 
 			// Load the factory internal representation.
-			state, err := newFactory(ctx, name, source, funcValue, getOutType, getOutValue, getOutClose, getOutError)
+			state, err := newFactory(name, source, funcValue, getOutType, getOutValue, getOutClose, getOutError)
 			if err != nil {
 				return fmt.Errorf("failed to load %s: %w", name, err)
 			}
@@ -206,7 +204,7 @@ func NewService[T any](service T, opts ...FactoryOption) *Factory {
 		name:        name,
 		source:      source,
 		annotations: settings.annotations,
-		register: func(ctx context.Context, registry *registry) error {
+		register: func(registry *registry) error {
 			// Prepare value and error getters.
 			getOutType := func(outTypes []reflect.Type) reflect.Type { return funcType.Out(0) }
 			getOutValue := func(outValues []reflect.Value) reflect.Value { return outValues[0] }
@@ -214,7 +212,7 @@ func NewService[T any](service T, opts ...FactoryOption) *Factory {
 			getOutError := func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
 
 			// Load the factory internal representation.
-			state, err := newFactory(ctx, name, source, funcValue, getOutType, getOutValue, getOutClose, getOutError)
+			state, err := newFactory(name, source, funcValue, getOutType, getOutValue, getOutClose, getOutError)
 			if err != nil {
 				return fmt.Errorf("failed to load %s: %w", name, err)
 			}
@@ -239,7 +237,7 @@ type Factory struct {
 	name        string
 	source      string
 	annotations []any
-	register    func(ctx context.Context, registry *registry) error
+	register    func(registry *registry) error
 }
 
 // Name returns the human-readable name of the factory.
@@ -258,8 +256,8 @@ func (f *Factory) Annotations() []any {
 }
 
 // apply applies the factory option to the given registry.
-func (f *Factory) apply(ctx context.Context, registry *registry) error {
-	return f.register(ctx, registry)
+func (f *Factory) apply(registry *registry) error {
+	return f.register(registry)
 }
 
 // factorySettings holds configuration options applied to a Factory or Service.
@@ -297,7 +295,7 @@ func NewEntrypoint(function any, opts ...EntrypointOption) *Entrypoint {
 		name:        name,
 		source:      source,
 		annotations: settings.annotations,
-		register: func(ctx context.Context, registry *registry) error {
+		register: func(registry *registry) error {
 			// Validate function type.
 			if funcType.Kind() != reflect.Func {
 				return fmt.Errorf("invalid type: %s", funcType)
@@ -331,7 +329,7 @@ func NewEntrypoint(function any, opts ...EntrypointOption) *Entrypoint {
 			}
 
 			// Load the factory internal representation.
-			state, err := newFactory(ctx, name, source, funcValue, getOutType, getOutValue, getOutClose, getOutError)
+			state, err := newFactory(name, source, funcValue, getOutType, getOutValue, getOutClose, getOutError)
 			if err != nil {
 				return fmt.Errorf("failed to load %s: %w", name, err)
 			}
@@ -356,7 +354,7 @@ type Entrypoint struct {
 	name        string
 	source      string
 	annotations []any
-	register    func(ctx context.Context, registry *registry) error
+	register    func(registry *registry) error
 }
 
 // Name returns the human-readable name of the entrypoint.
@@ -375,8 +373,8 @@ func (e *Entrypoint) Annotations() []any {
 }
 
 // apply applies the entrypoint option to the given registry.
-func (e *Entrypoint) apply(ctx context.Context, registry *registry) error {
-	return e.register(ctx, registry)
+func (e *Entrypoint) apply(registry *registry) error {
+	return e.register(registry)
 }
 
 // entrypointSettings holds configuration options applied to an Entrypoint.

--- a/container_test.go
+++ b/container_test.go
@@ -18,7 +18,6 @@
 package gontainer
 
 import (
-	"context"
 	"fmt"
 	"reflect"
 	"sync/atomic"
@@ -42,7 +41,6 @@ func TestContainer(t *testing.T) {
 
 	// Run container.
 	equal(t, Run(
-		context.Background(),
 		NewService(float64(100500)),
 		NewFactory(func() string { return "string" }),
 		NewFactory(func() int { return 123 }),
@@ -60,7 +58,6 @@ func TestContainer(t *testing.T) {
 			}
 		}),
 		NewEntrypoint(func(
-			ctx context.Context,
 			dep1 float64,
 			dep2 string,
 			dep3 Optional[int],

--- a/container_test.go
+++ b/container_test.go
@@ -18,6 +18,7 @@
 package gontainer
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"sync/atomic"
@@ -121,4 +122,70 @@ func equal(t *testing.T, a, b any) {
 	if !reflect.DeepEqual(a, b) {
 		t.Fatalf("equal failed: '%v' != '%v'", a, b)
 	}
+}
+
+// TestDistinctTypes pins down the container's type-matching contract for
+// named types that share a common underlying type (e.g. `type UsersDB *sql.DB`
+// and `type OrdersDB *sql.DB`). Resolution is based on exact type identity:
+// there is no covariance between a defined type and its underlying type,
+// so users can register multiple instances of the "same" underlying type
+// by wrapping each one in a distinct named type.
+func TestDistinctTypes(t *testing.T) {
+	t.Run("DistinctDefinedTypesCoexist", func(t *testing.T) {
+		// Two defined pointer types share the same underlying `*connection`,
+		// yet the container treats them as fully independent service keys:
+		// both are registered without a duplicate-type error and each is
+		// injected into the entrypoint from its own factory.
+		type connection struct{ id string }
+		type usersDB *connection
+		type ordersDB *connection
+
+		var users usersDB
+		var orders ordersDB
+
+		equal(t, Run(
+			NewFactory(func() usersDB { return &connection{id: "users"} }),
+			NewFactory(func() ordersDB { return &connection{id: "orders"} }),
+			NewEntrypoint(func(u usersDB, o ordersDB) {
+				users = u
+				orders = o
+			}),
+		), nil)
+
+		equal(t, (*connection)(users).id, "users")
+		equal(t, (*connection)(orders).id, "orders")
+	})
+
+	t.Run("NoCovarianceBetweenDefinedAndUnderlying", func(t *testing.T) {
+		// A factory that returns a defined type does not satisfy a request
+		// for the underlying type: the container uses exact type matching,
+		// not assignability or convertibility.
+		type connection struct{ id string }
+		type usersDB *connection
+
+		err := Run(
+			NewFactory(func() usersDB { return &connection{id: "users"} }),
+			NewEntrypoint(func(_ *connection) {}),
+		)
+		equal(t, errors.Is(err, ErrDependencyNotResolved), true)
+	})
+
+	t.Run("MultipleDoesNotCollectDefinedTypes", func(t *testing.T) {
+		// Multiple[T] is polymorphic only for interfaces. For concrete types
+		// it follows the same exact-match rule, so it does not pick up
+		// factories of defined types that happen to share the same underlying.
+		type connection struct{ id string }
+		type usersDB *connection
+		type ordersDB *connection
+
+		var all Multiple[*connection]
+
+		equal(t, Run(
+			NewFactory(func() usersDB { return &connection{id: "users"} }),
+			NewFactory(func() ordersDB { return &connection{id: "orders"} }),
+			NewEntrypoint(func(m Multiple[*connection]) { all = m }),
+		), nil)
+
+		equal(t, len(all), 0)
+	})
 }

--- a/examples/01_console_command/main.go
+++ b/examples/01_console_command/main.go
@@ -18,7 +18,6 @@
 package main
 
 import (
-	"context"
 	"log"
 
 	"github.com/NVIDIA/gontainer/v2"
@@ -48,9 +47,6 @@ func main() {
 	// Execute service container.
 	log.Println("Executing service container")
 	err := gontainer.Run(
-		// Root context for container.
-		context.Background(),
-
 		// Factory to create an instance of NameService.
 		gontainer.NewFactory(func() *NameService {
 			return &NameService{name: "Bob"}

--- a/examples/02_daemon_service/main.go
+++ b/examples/02_daemon_service/main.go
@@ -54,9 +54,6 @@ func main() {
 	// Execute service container.
 	log.Println("Executing service container")
 	err := gontainer.Run(
-		// Root context for container.
-		context.Background(),
-
 		// Inject singleton object.
 		gontainer.NewService(logger),
 

--- a/examples/03_complete_webapp/main.go
+++ b/examples/03_complete_webapp/main.go
@@ -18,7 +18,6 @@
 package main
 
 import (
-	"context"
 	"os"
 	"os/signal"
 	"syscall"
@@ -44,9 +43,6 @@ func main() {
 
 	// Execute service container.
 	err := gontainer.Run(
-		// Root context for container.
-		context.Background(),
-
 		// Enable config service.
 		config.WithConfig(),
 

--- a/examples/04_transient_services/main.go
+++ b/examples/04_transient_services/main.go
@@ -18,7 +18,6 @@
 package main
 
 import (
-	"context"
 	"log"
 	"math/rand"
 
@@ -29,9 +28,6 @@ func main() {
 	// Execute service container.
 	log.Println("Executing service container")
 	err := gontainer.Run(
-		// Root context for container.
-		context.Background(),
-
 		// Return a function that returns an int.
 		gontainer.NewFactory(func() func() int {
 			// From the container perspective this is a regular service.

--- a/factory.go
+++ b/factory.go
@@ -18,7 +18,6 @@
 package gontainer
 
 import (
-	"context"
 	"reflect"
 	"runtime"
 	"strings"
@@ -64,7 +63,6 @@ func splitFuncName(funcFullName string) (string, string) {
 
 // newFactory loads factory function to the internal representation.
 func newFactory(
-	ctx context.Context,
 	name, source string, funcValue reflect.Value,
 	getOutType getOutTypeFn, getOutValue getOutValueFn,
 	getOutClose getOutCloseFn, getOutError getOutErrorFn,
@@ -84,13 +82,8 @@ func newFactory(
 		outTypes = append(outTypes, funcType.Out(index))
 	}
 
-	// Prepare cancellable context for the factory services.
-	ctx, cancel := context.WithCancel(context.WithoutCancel(ctx))
-
 	// Prepare registry factory instance.
 	return &factory{
-		ctx:       ctx,
-		cancel:    cancel,
 		name:      name,
 		source:    source,
 		funcType:  funcType,
@@ -108,12 +101,6 @@ func newFactory(
 
 // factory is the factory internal representation.
 type factory struct {
-	// Factory context value.
-	ctx context.Context
-
-	// Factory context cancel.
-	cancel context.CancelFunc
-
 	// Factory func name.
 	name string
 

--- a/factory_test.go
+++ b/factory_test.go
@@ -18,7 +18,6 @@
 package gontainer
 
 import (
-	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -30,10 +29,9 @@ func TestFactoryLoad(t *testing.T) {
 		return 100500, nil
 	}
 
-	ctx := context.Background()
 	option := NewFactory(fun)
 	registry := &registry{}
-	equal(t, option.apply(ctx, registry), nil)
+	equal(t, option.apply(registry), nil)
 	factory := registry.factories[0]
 
 	equal(t, factory.funcType.String(), "func(string, string, string) (int, error)")
@@ -87,9 +85,8 @@ func TestFactoryInfo(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
 			registry := &registry{}
-			equal(t, tt.arg1.apply(ctx, registry), nil)
+			equal(t, tt.arg1.apply(registry), nil)
 
 			factory := registry.factories[0]
 			equal(t, factory.name, tt.want1)

--- a/invoker_test.go
+++ b/invoker_test.go
@@ -18,7 +18,6 @@
 package gontainer
 
 import (
-	"context"
 	"errors"
 	"sync/atomic"
 	"testing"
@@ -109,7 +108,6 @@ func TestInvokerService(t *testing.T) {
 
 			// Run container.
 			equal(t, Run(
-				context.Background(),
 				NewFactory(func() string { return "string" }),
 				NewFactory(func() int { return 123 }),
 				NewEntrypoint(func(invoker *Invoker) {

--- a/registry.go
+++ b/registry.go
@@ -18,7 +18,6 @@
 package gontainer
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"reflect"
@@ -62,11 +61,6 @@ func (r *registry) validateRegistry() error {
 	// Validate all input types are resolvable.
 	for _, factory := range factories {
 		for _, inType := range factory.inTypes {
-			// Is this type a special factory context type?
-			if isContextInterface(inType) {
-				continue
-			}
-
 			// Is this type wrapped to the `Optional[type]`?
 			_, isOptional := isOptionalType(inType)
 			if isOptional {
@@ -122,11 +116,6 @@ func (r *registry) validateRegistry() error {
 			factories = factories[1:]
 
 			for _, inType := range factory.inTypes {
-				// Is this type a special factory context type?
-				if isContextInterface(inType) {
-					continue
-				}
-
 				// Is this type wrapped to the `Optional[type]`?
 				innerType, isOptional := isOptionalType(inType)
 				if isOptional {
@@ -204,11 +193,6 @@ func (r *registry) closeFactories() error {
 	// Close all spawned factories in the reverse order.
 	for index := len(r.sequence) - 1; index >= 0; index-- {
 		factory := r.sequence[index]
-
-		// Cancel factory context before calling close on services.
-		// This allows background goroutines to unblock from
-		// waiting of context done channels and finish work.
-		factory.cancel()
 
 		// Invoke close callback function.
 		if err := factory.getOutClose()(); err != nil {
@@ -390,13 +374,6 @@ func (r *registry) invokeFactory(factory *factory) error {
 	// Get or spawn factory input values recursively.
 	inValues := make([]reflect.Value, 0, len(factory.inTypes))
 	for _, inType := range factory.inTypes {
-		// Handle `context.Context` as a special case.
-		if isContextInterface(inType) {
-			ctxValue := reflect.ValueOf(factory.ctx)
-			inValues = append(inValues, ctxValue)
-			continue
-		}
-
 		// Resolve factory input dependency.
 		inValue, err := r.resolveService(inType)
 		if err != nil {
@@ -417,35 +394,9 @@ func (r *registry) invokeFactory(factory *factory) error {
 	return nil
 }
 
-// isUsefulService returns true if the type is a useful service.
-func isUsefulService(typ reflect.Type) bool {
-	// Any objects are not useful services.
-	if isEmptyInterface(typ) {
-		return false
-	}
-
-	// Contexts are not useful services.
-	if isContextInterface(typ) {
-		return false
-	}
-
-	// Errors are not useful services.
-	if isErrorInterface(typ) {
-		return false
-	}
-
-	return true
-}
-
 // isEmptyInterface returns true when argument is an `any` interface.
 func isEmptyInterface(typ reflect.Type) bool {
 	return typ.Kind() == reflect.Interface && typ.NumMethod() == 0
-}
-
-// isContextInterface returns true when argument is a context interface.
-func isContextInterface(typ reflect.Type) bool {
-	ctxType := reflect.TypeOf((*context.Context)(nil)).Elem()
-	return typ.Kind() == reflect.Interface && typ.Implements(ctxType)
 }
 
 // isErrorInterface returns true when argument is an error interface.

--- a/registry_test.go
+++ b/registry_test.go
@@ -18,7 +18,6 @@
 package gontainer
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"reflect"
@@ -34,10 +33,9 @@ func TestRegistryRegisterFactory(t *testing.T) {
 		return 1, nil
 	}
 
-	ctx := context.Background()
 	option := NewFactory(fun)
 	registry := &registry{}
-	equal(t, option.apply(ctx, registry), nil)
+	equal(t, option.apply(registry), nil)
 	factory := registry.factories[0]
 	equal(t, factory.funcValue.IsValid(), true)
 	equal(t, factory.funcValue.Kind(), reflect.Func)
@@ -149,12 +147,11 @@ func TestRegistryValidateFactories(t *testing.T) {
 		{
 			name: "ComplexErrors",
 			options: []Option{
-				NewFactory(func(struct{ X int }) string { return "s1" }),                   // not resolved, duplicate
-				NewFactory(func(ctx context.Context) (string, error) { return "s2", nil }), // duplicate
-				NewFactory(func(bool) (int, error) { return 1, nil }),                      // cycle
-				NewFactory(func(int) (bool, error) { return true, nil }),                   // cycle
-				NewFactory(func() string { return "s3" }),                                  // duplicate
-				NewEntrypoint(func(struct{ X int }) error { return nil }),                  // not resolved
+				NewFactory(func(struct{ X int }) string { return "s1" }),  // not resolved, duplicate
+				NewFactory(func(bool) (int, error) { return 1, nil }),     // cycle
+				NewFactory(func(int) (bool, error) { return true, nil }),  // cycle
+				NewFactory(func() string { return "s2" }),                 // duplicate
+				NewEntrypoint(func(struct{ X int }) error { return nil }), // not resolved
 			},
 			wantErr: func(t *testing.T, err error) {
 				equal(t, errors.Is(err, ErrDependencyNotResolved), true)
@@ -164,7 +161,7 @@ func TestRegistryValidateFactories(t *testing.T) {
 				unwrap, ok := err.(interface{ Unwrap() []error })
 				equal(t, ok, true)
 				errs := unwrap.Unwrap()
-				equal(t, len(errs), 7)
+				equal(t, len(errs), 6)
 
 				equal(t, errors.Is(errs[0], ErrDependencyNotResolved), true)
 				equal(t, errs[0].Error(), ""+
@@ -183,21 +180,16 @@ func TestRegistryValidateFactories(t *testing.T) {
 
 				equal(t, errors.Is(errs[3], ErrFactoryTypeDuplicated), true)
 				equal(t, errs[3].Error(), ""+
-					"Factory[func(context.Context) (string, error)] from 'github.com/NVIDIA/gontainer/v2': "+
-					"output 'string': factory type duplicated")
-
-				equal(t, errors.Is(errs[4], ErrFactoryTypeDuplicated), true)
-				equal(t, errs[4].Error(), ""+
 					"Factory[func() string] from 'github.com/NVIDIA/gontainer/v2': "+
 					"output 'string': factory type duplicated")
 
-				equal(t, errors.Is(errs[5], ErrCircularDependency), true)
-				equal(t, errs[5].Error(), ""+
+				equal(t, errors.Is(errs[4], ErrCircularDependency), true)
+				equal(t, errs[4].Error(), ""+
 					"Factory[func(bool) (int, error)] from 'github.com/NVIDIA/gontainer/v2': "+
 					"circular dependency")
 
-				equal(t, errors.Is(errs[6], ErrCircularDependency), true)
-				equal(t, errs[6].Error(), ""+
+				equal(t, errors.Is(errs[5], ErrCircularDependency), true)
+				equal(t, errs[5].Error(), ""+
 					"Factory[func(int) (bool, error)] from 'github.com/NVIDIA/gontainer/v2': "+
 					"circular dependency")
 			},
@@ -205,10 +197,9 @@ func TestRegistryValidateFactories(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
 			registry := &registry{}
 			for _, option := range tt.options {
-				equal(t, option.apply(ctx, registry), nil)
+				equal(t, option.apply(registry), nil)
 			}
 			tt.wantErr(t, registry.validateRegistry())
 		})
@@ -217,12 +208,11 @@ func TestRegistryValidateFactories(t *testing.T) {
 
 // TestRegistryInvokeFunctions tests corresponding registry method.
 func TestRegistryInvokeFunctions(t *testing.T) {
-	ctx := context.Background()
 	registry := &registry{}
 	invoked := atomic.Bool{}
 
-	equal(t, NewFactory(func() bool { return true }).apply(ctx, registry), nil)
-	equal(t, NewEntrypoint(func(_ bool) { invoked.Store(true) }).apply(ctx, registry), nil)
+	equal(t, NewFactory(func() bool { return true }).apply(registry), nil)
+	equal(t, NewEntrypoint(func(_ bool) { invoked.Store(true) }).apply(registry), nil)
 
 	factory := registry.factories[0]
 	equal(t, registry.invokeEntrypoints(), nil)
@@ -243,10 +233,9 @@ func TestRegistryResolveParallel(t *testing.T) {
 		return true
 	})
 
-	ctx := context.Background()
 	registry := &registry{}
 
-	equal(t, source.apply(ctx, registry), nil)
+	equal(t, source.apply(registry), nil)
 	factory := registry.factories[0]
 
 	wg := sync.WaitGroup{}
@@ -297,10 +286,9 @@ func TestRegistryResolveFuncServices(t *testing.T) {
 		}),
 	}
 
-	ctx := context.Background()
 	registry := &registry{}
 	for _, option := range options {
-		equal(t, option.apply(ctx, registry), nil)
+		equal(t, option.apply(registry), nil)
 	}
 
 	err := registry.invokeEntrypoints()
@@ -320,9 +308,8 @@ func TestRegistryResolveWithErrors(t *testing.T) {
 		return true, errors.New("some function-specific error message")
 	})
 
-	ctx := context.Background()
 	registry := &registry{}
-	equal(t, source.apply(ctx, registry), nil)
+	equal(t, source.apply(registry), nil)
 
 	value, err := registry.resolveService(reflect.TypeOf(true))
 	equal(t, err != nil, true)
@@ -339,9 +326,8 @@ func TestRegistryInvokeWithErrors(t *testing.T) {
 		return errors.New("some function-specific error message")
 	})
 
-	ctx := context.Background()
 	registry := &registry{}
-	equal(t, source.apply(ctx, registry), nil)
+	equal(t, source.apply(registry), nil)
 
 	err := registry.invokeEntrypoints()
 	equal(t, err != nil, true)
@@ -364,21 +350,6 @@ func TestIsEmptyInterface(t *testing.T) {
 	equal(t, isEmptyInterface(reflect.TypeOf(&t3).Elem()), false)
 	equal(t, isEmptyInterface(reflect.TypeOf(&t4).Elem()), false)
 	equal(t, isEmptyInterface(reflect.TypeOf(&t5).Elem()), false)
-}
-
-// TestIsContextInterface tests checking of argument to be context.
-func TestIsContextInterface(t *testing.T) {
-	var t1 any
-	var t2 interface{}
-	var t3 struct{}
-	var t4 string
-	var t5 context.Context
-
-	equal(t, isContextInterface(reflect.TypeOf(&t1).Elem()), false)
-	equal(t, isContextInterface(reflect.TypeOf(&t2).Elem()), false)
-	equal(t, isContextInterface(reflect.TypeOf(&t3).Elem()), false)
-	equal(t, isContextInterface(reflect.TypeOf(&t4).Elem()), false)
-	equal(t, isContextInterface(reflect.TypeOf(&t5).Elem()), true)
 }
 
 // TestIsErrorInterface tests checking of argument to be error.

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -18,7 +18,6 @@
 package gontainer
 
 import (
-	"context"
 	"sync/atomic"
 	"testing"
 )
@@ -33,7 +32,6 @@ func TestResolverService(t *testing.T) {
 
 	// Run container.
 	equal(t, Run(
-		context.Background(),
 		NewService(svc1),
 		NewService(svc2),
 		NewEntrypoint(func(resolver *Resolver) {


### PR DESCRIPTION
This pull request simplifies the API of the `gontainer` library by removing the need to pass a `context.Context` to most public APIs, updates the documentation and examples to reflect this change, and clarifies the rules for registering and resolving multiple instances of the same underlying type. It also adds new tests to pin down the behavior for distinct named types. The most important changes are summarized below.

### API Simplification

* The `Run` function and related APIs no longer require a `context.Context` parameter; all context handling is now internal. This change affects the signatures of `Run`, `Option`, `Factory`, and `Entrypoint` methods, as well as their usage throughout the codebase. (`container.go`, `README.md`, `examples/01_console_command/main.go`, [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L29) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L40-L41) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L160) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L296-R346) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L307-R357) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L349-L354) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L385-R432) [[8]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL21-R32) [[9]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL45-R54) [[10]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL82-R80) [[11]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL115-R113) [[12]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL130-R149) [[13]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL163-R161) [[14]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL209-R215) [[15]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL242-R240) [[16]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL261-R260) [[17]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL300-R298) [[18]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL334-R332) [[19]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL359-R357) [[20]](diffhunk://#diff-14bacfb63a209323729af295c64c9bb978c84e810d18e3e7b7ae66d9b3cd7acaL378-R377) [[21]](diffhunk://#diff-aeeaf3883448a89ac0c0e17bd2ad35d1f5921f2080fd41728fcf2bb0b3889789L21) [[22]](diffhunk://#diff-b1eb9afa48ad78a73fcc18342b9da970021b71d1eb6cf6e391a80012a31cbfd3L45) [[23]](diffhunk://#diff-b1eb9afa48ad78a73fcc18342b9da970021b71d1eb6cf6e391a80012a31cbfd3L63)

### Documentation and Example Updates

* The `README.md` and example code have been updated to remove references to passing a context, and to clarify that service registration and resolution are now based strictly on exact type identity. The documentation now includes a new section explaining how to register multiple instances of the same underlying type using named types or composite services. (`README.md`, [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R220-R273) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L326-R376) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L349-L354)

### Type Matching and Multiple Instances

* The rules for service resolution have been clarified: services are matched by exact type, not by underlying type or assignability. This enables registering multiple instances of the same underlying type by wrapping them in distinct named types. (`README.md`, [README.mdR220-R273](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R220-R273))

### Test Coverage

* New tests have been added to ensure that distinct named types are treated as independent service keys, that there is no covariance between defined types and their underlying types, and that `Multiple[T]` only collects exact matches. (`container_test.go`, [container_test.goR126-R191](diffhunk://#diff-b1eb9afa48ad78a73fcc18342b9da970021b71d1eb6cf6e391a80012a31cbfd3R126-R191))

---

These changes make the API easier to use, improve documentation, and clarify the container's type-matching contract.