### PR TITLE
Fix of error handling while invoking entrypoints

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -169,6 +169,9 @@ func (r *registry) invokeEntrypoints() error {
 				"%s from '%s': invoke: %w",
 				factory.name, factory.source, err,
 			))
+
+			// The entrypoint was not invoked.
+			continue
 		}
 
 		// Handle factory error.

--- a/registry_test.go
+++ b/registry_test.go
@@ -337,6 +337,72 @@ func TestRegistryInvokeWithErrors(t *testing.T) {
 	equal(t, errors.Is(err, ErrEntrypointReturnedError), true)
 }
 
+// TestRegistryInvokeEntrypointWithFailedDependency tests that a failed dependency
+// factory does not cause a nil-slice panic when the entrypoint returns an error.
+func TestRegistryInvokeEntrypointWithFailedDependency(t *testing.T) {
+	options := []Option{
+		NewFactory(func() (string, error) {
+			return "", errors.New("dependency factory error")
+		}),
+		NewEntrypoint(func(string) error { return nil }),
+	}
+
+	registry := &registry{}
+	for _, option := range options {
+		equal(t, option.apply(registry), nil)
+	}
+
+	err := registry.invokeEntrypoints()
+	equal(t, err != nil, true)
+	equal(t, errors.Is(err, ErrFactoryReturnedError), true)
+	equal(t, fmt.Sprint(err), ""+
+		"Entrypoint[func(string) error] from 'github.com/NVIDIA/gontainer/v2': "+
+		"invoke: failed to resolve service: "+
+		"Factory[func() (string, error)] from 'github.com/NVIDIA/gontainer/v2': "+
+		"factory returned error: dependency factory error")
+}
+
+// TestRegistryInvokeMultipleEntrypointsWithFailedDependency tests that a failed
+// dependency on one entrypoint does not abort invocation of the rest.
+func TestRegistryInvokeMultipleEntrypointsWithFailedDependency(t *testing.T) {
+	secondInvoked := false
+
+	options := []Option{
+		NewFactory(func() (string, error) {
+			return "", errors.New("dependency factory error")
+		}),
+		NewEntrypoint(func(string) error { return nil }),
+		NewEntrypoint(func() error {
+			secondInvoked = true
+			return errors.New("second entrypoint error")
+		}),
+	}
+
+	registry := &registry{}
+	for _, option := range options {
+		equal(t, option.apply(registry), nil)
+	}
+
+	err := registry.invokeEntrypoints()
+	equal(t, err != nil, true)
+	equal(t, secondInvoked, true)
+	equal(t, errors.Is(err, ErrFactoryReturnedError), true)
+	equal(t, errors.Is(err, ErrEntrypointReturnedError), true)
+
+	unwrap, ok := err.(interface{ Unwrap() []error })
+	equal(t, ok, true)
+	errs := unwrap.Unwrap()
+	equal(t, len(errs), 2)
+	equal(t, errs[0].Error(), ""+
+		"Entrypoint[func(string) error] from 'github.com/NVIDIA/gontainer/v2': "+
+		"invoke: failed to resolve service: "+
+		"Factory[func() (string, error)] from 'github.com/NVIDIA/gontainer/v2': "+
+		"factory returned error: dependency factory error")
+	equal(t, errs[1].Error(), ""+
+		"Entrypoint[func() error] from 'github.com/NVIDIA/gontainer/v2': "+
+		"entrypoint returned error: second entrypoint error")
+}
+
 // TestIsEmptyInterface tests checking of argument to be empty interface.
 func TestIsEmptyInterface(t *testing.T) {
 	var t1 any


### PR DESCRIPTION
This pull request improves the robustness of the `invokeEntrypoints` logic in `registry.go` and enhances test coverage to ensure correct behavior when entrypoint dependencies fail. The changes ensure that if an entrypoint's dependencies cannot be resolved due to a factory error, the entrypoint is skipped without causing a panic, and that other entrypoints continue to be invoked. Comprehensive tests are added to verify these behaviors.

Error handling improvements:

* Updated `invokeEntrypoints` in `registry.go` to skip entrypoints whose dependencies fail to resolve, preventing a panic and ensuring the rest of the entrypoints are still processed.

Test coverage enhancements:

* Added `TestRegistryInvokeEntrypointWithFailedDependency` to verify that a failed dependency does not cause a nil-slice panic and that the correct error is returned.
* Added `TestRegistryInvokeMultipleEntrypointsWithFailedDependency` to ensure that failure in one entrypoint's dependencies does not prevent other entrypoints from being invoked, and that all relevant errors are reported.