### PR TITLE
Improved errors reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,37 @@ func(providers gontainer.Multiple[AuthProvider]) *Router
 
 ## Error Handling
 
-Gontainer provides typed errors for different failure scenarios:
+Container errors are rendered as a structured traceback: the root cause
+on the first line, followed by resolution frames with `file:line`
+references.
+
+Startup error - error returned by a factory:
+
+```
+Configuration load failed:
+ - DATABASE_USERNAME: required environment variable is not set
+ - DATABASE_PASSWORD: required environment variable is not set
+
+Traceback:
+  Factory for *myapp.Config
+    at /path/to/app/config.go:18
+  Factory for *myapp.Database
+    at /path/to/app/db.go:24
+  Entrypoint
+    at /path/to/app/main.go:15
+```
+
+Close error - errors returned from close callbacks:
+
+```
+connection reset by peer
+
+Source:
+  Factory for *myapp.Database
+    at /path/to/app/db.go:24
+```
+
+Typed errors are also exposed for programmatic matching:
 
 ```go
 err := gontainer.Run(factories...)

--- a/container.go
+++ b/container.go
@@ -20,6 +20,7 @@ package gontainer
 import (
 	"fmt"
 	"reflect"
+	"runtime"
 	"slices"
 )
 
@@ -97,7 +98,7 @@ func NewFactory(function any, opts ...FactoryOption) *Factory {
 
 	// Prepare factory description.
 	name := fmt.Sprintf("Factory[%s]", funcValue.Type())
-	source := getFuncSource(funcValue)
+	source := getCallerSource(1)
 
 	// Prepare factory settings.
 	settings := factorySettings{}
@@ -191,7 +192,7 @@ func NewService[T any](service T, opts ...FactoryOption) *Factory {
 
 	// Prepare factory description.
 	name := fmt.Sprintf("Service[%s]", serviceType)
-	source := serviceType.PkgPath()
+	source := getCallerSource(1)
 
 	// Prepare factory settings.
 	settings := factorySettings{}
@@ -282,7 +283,7 @@ func NewEntrypoint(function any, opts ...EntrypointOption) *Entrypoint {
 
 	// Prepare entrypoint description.
 	name := fmt.Sprintf("Entrypoint[%s]", funcValue.Type())
-	source := getFuncSource(funcValue)
+	source := getCallerSource(1)
 
 	// Prepare entrypoint settings.
 	settings := entrypointSettings{}
@@ -405,4 +406,13 @@ func (m annotationOpt) applyFactory(s *factorySettings) {
 // applyEntrypointSettings applies the option to the entrypoint settings.
 func (m annotationOpt) applyEntrypoint(s *entrypointSettings) {
 	s.appendAnnotation(m.value)
+}
+
+// getCallerSource returns the "<file>:<line>" of the skip-level caller.
+func getCallerSource(skip int) string {
+	_, file, line, ok := runtime.Caller(skip + 1)
+	if !ok {
+		return ""
+	}
+	return fmt.Sprintf("%s:%d", file, line)
 }

--- a/container.go
+++ b/container.go
@@ -41,34 +41,34 @@ func Run(options ...Option) error {
 
 	// Register service resolver instance in the registry.
 	if err := NewService(resolver).apply(registry); err != nil {
-		return fmt.Errorf("failed to register resolver: %w", err)
+		return err
 	}
 
 	// Register function invoker instance in the registry.
 	if err := NewService(invoker).apply(registry); err != nil {
-		return fmt.Errorf("failed to register invoker: %w", err)
+		return err
 	}
 
 	// Register provided factories in the registry.
 	for _, option := range options {
 		if err := option.apply(registry); err != nil {
-			return fmt.Errorf("failed to apply option: %w", err)
+			return err
 		}
 	}
 
 	// Validate all factories in the container.
 	if err := registry.validateRegistry(); err != nil {
-		return fmt.Errorf("failed to validate container: %w", err)
+		return err
 	}
 
 	// Start all factories in the container.
 	if err := registry.invokeEntrypoints(); err != nil {
-		return fmt.Errorf("failed to invoke functions: %w", err)
+		return err
 	}
 
 	// Close all factories in the container.
 	if err := registry.closeFactories(); err != nil {
-		return fmt.Errorf("failed to close factories: %w", err)
+		return err
 	}
 
 	// Service container executed.

--- a/container.go
+++ b/container.go
@@ -159,7 +159,10 @@ func NewFactory(function any, opts ...FactoryOption) *Factory {
 			}
 
 			// Load the factory internal representation.
-			state, err := newFactory(name, source, funcValue, getOutType, getOutValue, getOutClose, getOutError)
+			state, err := newFactory(
+				kindFactory, name, source, funcValue,
+				getOutType, getOutValue, getOutClose, getOutError,
+			)
 			if err != nil {
 				return fmt.Errorf("failed to load %s: %w", name, err)
 			}
@@ -213,7 +216,10 @@ func NewService[T any](service T, opts ...FactoryOption) *Factory {
 			getOutError := func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
 
 			// Load the factory internal representation.
-			state, err := newFactory(name, source, funcValue, getOutType, getOutValue, getOutClose, getOutError)
+			state, err := newFactory(
+				kindFactory, name, source, funcValue,
+				getOutType, getOutValue, getOutClose, getOutError,
+			)
 			if err != nil {
 				return fmt.Errorf("failed to load %s: %w", name, err)
 			}
@@ -330,7 +336,10 @@ func NewEntrypoint(function any, opts ...EntrypointOption) *Entrypoint {
 			}
 
 			// Load the factory internal representation.
-			state, err := newFactory(name, source, funcValue, getOutType, getOutValue, getOutClose, getOutError)
+			state, err := newFactory(
+				kindEntrypoint, name, source, funcValue,
+				getOutType, getOutValue, getOutClose, getOutError,
+			)
 			if err != nil {
 				return fmt.Errorf("failed to load %s: %w", name, err)
 			}

--- a/container_test.go
+++ b/container_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"regexp"
 	"sync/atomic"
 	"testing"
 )
@@ -188,4 +189,13 @@ func TestDistinctTypes(t *testing.T) {
 
 		equal(t, len(all), 0)
 	})
+}
+
+// normalizeSourceLines strips every "    at <file>:<line>" meta line
+// from a rendered error so tests can assert the structural shape of
+// Traceback / Source blocks without pinning brittle file paths or
+// line numbers.
+func normalizeSourceLines(s string) string {
+	sourceLineRegex := regexp.MustCompile(`\n {4}at [^\n]+`)
+	return sourceLineRegex.ReplaceAllString(s, "")
 }

--- a/errors.go
+++ b/errors.go
@@ -68,12 +68,16 @@ func formatTerminalError(err error) string {
 	if wrapped, ok := err.(interface{ Unwrap() error }); ok {
 		if inner := wrapped.Unwrap(); inner != nil {
 			if multi, ok := inner.(interface{ Unwrap() []error }); ok {
-				header := strings.TrimRight(strings.TrimSuffix(err.Error(), inner.Error()), ": \n\t")
-				joined := formatJoinedErrors(multi.Unwrap())
-				if header == "" {
-					return joined
+				outer := err.Error()
+				innerStr := inner.Error()
+				if strings.HasSuffix(outer, innerStr) {
+					header := strings.TrimRight(strings.TrimSuffix(outer, innerStr), ": \n\t")
+					joined := formatJoinedErrors(multi.Unwrap())
+					if header == "" {
+						return joined
+					}
+					return header + ":\n" + joined
 				}
-				return header + ":\n" + joined
 			}
 		}
 	}
@@ -129,9 +133,8 @@ func newEntrypointReturnedErrorError(f *factory, err error) error {
 }
 
 // newFactoryCloseFailedError wraps a raw close-callback error under a Source section with f as the sole frame.
-func newFactoryCloseFailedError(f *factory, cause error) error {
-	return fmt.Errorf("%s\n\nSource:%s%.0w",
-		formatTerminalError(cause), formatFactoryFrame(f), cause)
+func newFactoryCloseFailedError(f *factory, err error) error {
+	return fmt.Errorf("%s\n\nSource:%s%.0w", formatTerminalError(err), formatFactoryFrame(f), err)
 }
 
 // errorGroup is a group of independent errors, separated by a blank line when rendered.

--- a/errors.go
+++ b/errors.go
@@ -19,6 +19,9 @@ package gontainer
 
 import (
 	"errors"
+	"fmt"
+	"reflect"
+	"strings"
 )
 
 // ErrFactoryTypeDuplicated declares service duplicated error.
@@ -38,3 +41,112 @@ var ErrDependencyNotResolved = errors.New("dependency not resolved")
 
 // ErrCircularDependency declares a circular dependency error.
 var ErrCircularDependency = errors.New("circular dependency")
+
+// formatFactoryFrame renders a single factory or entrypoint as one traceback frame.
+func formatFactoryFrame(f *factory) string {
+	var sb strings.Builder
+	sb.WriteString("\n  ")
+	if f.kind == kindEntrypoint {
+		sb.WriteString("Entrypoint")
+	} else {
+		sb.WriteString("Factory for ")
+		sb.WriteString(f.getOutType().String())
+	}
+	if f.source != "" {
+		sb.WriteString("\n    at ")
+		sb.WriteString(f.source)
+	}
+	return sb.String()
+}
+
+// formatTerminalError renders a raw user error as a headline, expanding errors.Join children to bullets.
+func formatTerminalError(err error) string {
+	if multi, ok := err.(interface{ Unwrap() []error }); ok {
+		return formatJoinedErrors(multi.Unwrap())
+	}
+
+	if wrapped, ok := err.(interface{ Unwrap() error }); ok {
+		if inner := wrapped.Unwrap(); inner != nil {
+			if multi, ok := inner.(interface{ Unwrap() []error }); ok {
+				header := strings.TrimRight(strings.TrimSuffix(err.Error(), inner.Error()), ": \n\t")
+				joined := formatJoinedErrors(multi.Unwrap())
+				if header == "" {
+					return joined
+				}
+				return header + ":\n" + joined
+			}
+		}
+	}
+
+	return err.Error()
+}
+
+// formatJoinedErrors renders a slice of errors as bullet lines.
+func formatJoinedErrors(errs []error) string {
+	var sb strings.Builder
+	for i, e := range errs {
+		if i > 0 {
+			sb.WriteString("\n")
+		}
+		sb.WriteString("- ")
+		sb.WriteString(e.Error())
+	}
+	return sb.String()
+}
+
+// newDependencyNotResolvedError reports that no factory could satisfy missing for requester.
+func newDependencyNotResolvedError(requester *factory, missing reflect.Type) error {
+	tail := "\n\nTraceback:"
+	if requester != nil {
+		tail += formatFactoryFrame(requester)
+	}
+	return fmt.Errorf("%w: %s%s", ErrDependencyNotResolved, missing, tail)
+}
+
+// newFactoryTypeDuplicatedError reports that more than one factory produces the same output type.
+func newFactoryTypeDuplicatedError(f *factory) error {
+	return fmt.Errorf("%w: %s\n\nTraceback:%s", ErrFactoryTypeDuplicated, f.getOutType(), formatFactoryFrame(f))
+}
+
+// newCircularDependencyError reports a cycle in the dependency graph starting at f.
+func newCircularDependencyError(f *factory) error {
+	return fmt.Errorf("%w\n\nTraceback:%s", ErrCircularDependency, formatFactoryFrame(f))
+}
+
+// newFactoryResolveFailedError appends f as an outer frame to an already-rendered resolve error.
+func newFactoryResolveFailedError(f *factory, err error) error {
+	return fmt.Errorf("%w%s", err, formatFactoryFrame(f))
+}
+
+// newFactoryReturnedErrorError wraps a raw user error returned by a service factory and opens a Traceback section.
+func newFactoryReturnedErrorError(f *factory, err error) error {
+	return fmt.Errorf("%s\n\nTraceback:%s%.0w%.0w", formatTerminalError(err), formatFactoryFrame(f), err, ErrFactoryReturnedError)
+}
+
+// newEntrypointReturnedErrorError wraps a raw user error returned by an entrypoint and opens a Traceback section.
+func newEntrypointReturnedErrorError(f *factory, err error) error {
+	return fmt.Errorf("%s\n\nTraceback:%s%.0w%.0w", formatTerminalError(err), formatFactoryFrame(f), err, ErrEntrypointReturnedError)
+}
+
+// newFactoryCloseFailedError wraps a raw close-callback error under a Source section with f as the sole frame.
+func newFactoryCloseFailedError(f *factory, cause error) error {
+	return fmt.Errorf("%s\n\nSource:%s%.0w",
+		formatTerminalError(cause), formatFactoryFrame(f), cause)
+}
+
+// errorGroup is a group of independent errors, separated by a blank line when rendered.
+type errorGroup []error
+
+// Error renders each child error separated by a blank line.
+func (g errorGroup) Error() string {
+	parts := make([]string, 0, len(g))
+	for _, err := range g {
+		parts = append(parts, err.Error())
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+// Unwrap exposes the underlying errors so errors.Is can walk into each child independently.
+func (g errorGroup) Unwrap() []error {
+	return g
+}

--- a/errors.go
+++ b/errors.go
@@ -59,45 +59,6 @@ func formatFactoryFrame(f *factory) string {
 	return sb.String()
 }
 
-// formatTerminalError renders a raw user error as a headline, expanding errors.Join children to bullets.
-func formatTerminalError(err error) string {
-	if multi, ok := err.(interface{ Unwrap() []error }); ok {
-		return formatJoinedErrors(multi.Unwrap())
-	}
-
-	if wrapped, ok := err.(interface{ Unwrap() error }); ok {
-		if inner := wrapped.Unwrap(); inner != nil {
-			if multi, ok := inner.(interface{ Unwrap() []error }); ok {
-				outer := err.Error()
-				innerStr := inner.Error()
-				if strings.HasSuffix(outer, innerStr) {
-					header := strings.TrimRight(strings.TrimSuffix(outer, innerStr), ": \n\t")
-					joined := formatJoinedErrors(multi.Unwrap())
-					if header == "" {
-						return joined
-					}
-					return header + ":\n" + joined
-				}
-			}
-		}
-	}
-
-	return err.Error()
-}
-
-// formatJoinedErrors renders a slice of errors as bullet lines.
-func formatJoinedErrors(errs []error) string {
-	var sb strings.Builder
-	for i, e := range errs {
-		if i > 0 {
-			sb.WriteString("\n")
-		}
-		sb.WriteString("- ")
-		sb.WriteString(e.Error())
-	}
-	return sb.String()
-}
-
 // newDependencyNotResolvedError reports that no factory could satisfy missing for requester.
 func newDependencyNotResolvedError(requester *factory, missing reflect.Type) error {
 	tail := "\n\nTraceback:"
@@ -124,17 +85,17 @@ func newFactoryResolveFailedError(f *factory, err error) error {
 
 // newFactoryReturnedErrorError wraps a raw user error returned by a service factory and opens a Traceback section.
 func newFactoryReturnedErrorError(f *factory, err error) error {
-	return fmt.Errorf("%s\n\nTraceback:%s%.0w%.0w", formatTerminalError(err), formatFactoryFrame(f), err, ErrFactoryReturnedError)
+	return fmt.Errorf("%w\n\nTraceback:%s%.0w", err, formatFactoryFrame(f), ErrFactoryReturnedError)
 }
 
 // newEntrypointReturnedErrorError wraps a raw user error returned by an entrypoint and opens a Traceback section.
 func newEntrypointReturnedErrorError(f *factory, err error) error {
-	return fmt.Errorf("%s\n\nTraceback:%s%.0w%.0w", formatTerminalError(err), formatFactoryFrame(f), err, ErrEntrypointReturnedError)
+	return fmt.Errorf("%w\n\nTraceback:%s%.0w", err, formatFactoryFrame(f), ErrEntrypointReturnedError)
 }
 
 // newFactoryCloseFailedError wraps a raw close-callback error under a Source section with f as the sole frame.
 func newFactoryCloseFailedError(f *factory, err error) error {
-	return fmt.Errorf("%s\n\nSource:%s%.0w", formatTerminalError(err), formatFactoryFrame(f), err)
+	return fmt.Errorf("%w\n\nSource:%s", err, formatFactoryFrame(f))
 }
 
 // errorGroup is a group of independent errors, separated by a blank line when rendered.

--- a/errors.go
+++ b/errors.go
@@ -46,9 +46,10 @@ var ErrCircularDependency = errors.New("circular dependency")
 func formatFactoryFrame(f *factory) string {
 	var sb strings.Builder
 	sb.WriteString("\n  ")
-	if f.kind == kindEntrypoint {
+	switch f.kind {
+	case kindEntrypoint:
 		sb.WriteString("Entrypoint")
-	} else {
+	case kindFactory:
 		sb.WriteString("Factory for ")
 		sb.WriteString(f.getOutType().String())
 	}

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,444 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2003 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gontainer
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"testing"
+)
+
+// Synthetic types used to produce deterministic factory output types in rendered error traces.
+type testFmtRootA struct{}
+type testFmtRootB struct{}
+type testFmtMid struct{}
+type testFmtLeaf struct{}
+
+// testFmtTypedErr is a custom user error type used to verify errors.As walking down the resolve chain.
+type testFmtTypedErr struct {
+	msg string
+}
+
+// Error returns the error message.
+func (e *testFmtTypedErr) Error() string {
+	return e.msg
+}
+
+// TestErrorFormatSingleFactoryOneLineCause checks a one-line cause with a two-frame Traceback.
+func TestErrorFormatSingleFactoryOneLineCause(t *testing.T) {
+	err := Run(
+		NewFactory(func() (*testFmtLeaf, error) {
+			return nil, errors.New("boom")
+		}),
+		NewEntrypoint(func(*testFmtLeaf) {}),
+	)
+
+	equal(t, err != nil, true)
+	equal(t, normalizeSourceLines(err.Error()), ""+
+		"boom"+
+		"\n"+
+		"\nTraceback:"+
+		"\n  Factory for *gontainer.testFmtLeaf"+
+		"\n  Entrypoint")
+	equal(t, errors.Is(err, ErrFactoryReturnedError), true)
+}
+
+// TestErrorFormatDeepChainOneLineCause checks 4 frames with innermost first, outermost last.
+func TestErrorFormatDeepChainOneLineCause(t *testing.T) {
+	err := Run(
+		NewFactory(func() (*testFmtLeaf, error) {
+			return nil, errors.New("leaf boom")
+		}),
+		NewFactory(func(*testFmtLeaf) *testFmtMid {
+			return &testFmtMid{}
+		}),
+		NewFactory(func(*testFmtMid) *testFmtRootA {
+			return &testFmtRootA{}
+		}),
+		NewEntrypoint(func(*testFmtRootA) {}),
+	)
+
+	equal(t, err != nil, true)
+	equal(t, normalizeSourceLines(err.Error()), ""+
+		"leaf boom"+
+		"\n"+
+		"\nTraceback:"+
+		"\n  Factory for *gontainer.testFmtLeaf"+
+		"\n  Factory for *gontainer.testFmtMid"+
+		"\n  Factory for *gontainer.testFmtRootA"+
+		"\n  Entrypoint")
+	equal(t, errors.Is(err, ErrFactoryReturnedError), true)
+}
+
+// TestErrorFormatDeepChainJoinCause checks that an errors.Join cause renders each item as a "- " bullet.
+func TestErrorFormatDeepChainJoinCause(t *testing.T) {
+	joined := errors.Join(
+		errors.New("FIELD_A: 'required' rule failed"),
+		errors.New("FIELD_B: 'required' rule failed"),
+	)
+
+	err := Run(
+		NewFactory(func() (*testFmtLeaf, error) {
+			return nil, joined
+		}),
+		NewFactory(func(*testFmtLeaf) *testFmtMid {
+			return &testFmtMid{}
+		}),
+		NewEntrypoint(func(*testFmtMid) {}),
+	)
+
+	equal(t, err != nil, true)
+	equal(t, normalizeSourceLines(err.Error()), ""+
+		"- FIELD_A: 'required' rule failed"+
+		"\n- FIELD_B: 'required' rule failed"+
+		"\n"+
+		"\nTraceback:"+
+		"\n  Factory for *gontainer.testFmtLeaf"+
+		"\n  Factory for *gontainer.testFmtMid"+
+		"\n  Entrypoint")
+	equal(t, errors.Is(err, ErrFactoryReturnedError), true)
+}
+
+// TestErrorFormatDeepChainWrapperOverJoin checks that a wrapper adds a header line above bullets from an inner Join.
+func TestErrorFormatDeepChainWrapperOverJoin(t *testing.T) {
+	joined := errors.Join(
+		errors.New("URL: 'required' rule failed"),
+		errors.New("TOKEN: 'required' rule failed"),
+	)
+	wrapped := fmt.Errorf("failed to load GitLab client config: %w", joined)
+
+	err := Run(
+		NewFactory(func() (*testFmtLeaf, error) {
+			return nil, wrapped
+		}),
+		NewFactory(func(*testFmtLeaf) *testFmtMid {
+			return &testFmtMid{}
+		}),
+		NewEntrypoint(func(*testFmtMid) {}),
+	)
+
+	equal(t, err != nil, true)
+	equal(t, normalizeSourceLines(err.Error()), ""+
+		"failed to load GitLab client config:"+
+		"\n- URL: 'required' rule failed"+
+		"\n- TOKEN: 'required' rule failed"+
+		"\n"+
+		"\nTraceback:"+
+		"\n  Factory for *gontainer.testFmtLeaf"+
+		"\n  Factory for *gontainer.testFmtMid"+
+		"\n  Entrypoint")
+	equal(t, errors.Is(err, ErrFactoryReturnedError), true)
+}
+
+// TestErrorFormatDependencyNotResolvedTail checks the "dependency not resolved: T" headline followed by a Traceback.
+func TestErrorFormatDependencyNotResolvedTail(t *testing.T) {
+	r := &registry{}
+	equal(t, NewFactory(func(*testFmtLeaf) *testFmtMid {
+		return &testFmtMid{}
+	}).apply(r), nil)
+	equal(t, NewEntrypoint(func(*testFmtMid) {}).apply(r), nil)
+
+	err := r.invokeEntrypoints()
+
+	equal(t, err != nil, true)
+	equal(t, normalizeSourceLines(err.Error()), ""+
+		"dependency not resolved: *gontainer.testFmtLeaf"+
+		"\n"+
+		"\nTraceback:"+
+		"\n  Factory for *gontainer.testFmtMid"+
+		"\n  Entrypoint")
+	equal(t, errors.Is(err, ErrDependencyNotResolved), true)
+}
+
+// TestErrorFormatCircularDependencyTail checks that each factory in the cycle reports its own "circular dependency" block.
+func TestErrorFormatCircularDependencyTail(t *testing.T) {
+	err := Run(
+		NewFactory(func(*testFmtMid) *testFmtRootA { return &testFmtRootA{} }),
+		NewFactory(func(*testFmtRootA) *testFmtMid { return &testFmtMid{} }),
+		NewEntrypoint(func(*testFmtRootA) {}),
+	)
+
+	equal(t, err != nil, true)
+	equal(t, errors.Is(err, ErrCircularDependency), true)
+
+	unwrap, ok := err.(interface{ Unwrap() []error })
+	equal(t, ok, true)
+	errs := unwrap.Unwrap()
+	equal(t, len(errs), 2)
+	equal(t, normalizeSourceLines(errs[0].Error()), ""+
+		"circular dependency"+
+		"\n"+
+		"\nTraceback:"+
+		"\n  Factory for *gontainer.testFmtRootA")
+	equal(t, normalizeSourceLines(errs[1].Error()), ""+
+		"circular dependency"+
+		"\n"+
+		"\nTraceback:"+
+		"\n  Factory for *gontainer.testFmtMid")
+}
+
+// TestErrorFormatMultipleTopLevelChains checks that two independent entrypoint failures are separated by a single blank line.
+func TestErrorFormatMultipleTopLevelChains(t *testing.T) {
+	err := Run(
+		NewFactory(func() (*testFmtLeaf, error) {
+			return nil, errors.New("leaf error")
+		}),
+		NewEntrypoint(func(*testFmtLeaf) error { return nil }),
+		NewEntrypoint(func() error {
+			return errors.New("second entrypoint error")
+		}),
+	)
+
+	equal(t, err != nil, true)
+	equal(t, errors.Is(err, ErrFactoryReturnedError), true)
+	equal(t, errors.Is(err, ErrEntrypointReturnedError), true)
+
+	equal(t, normalizeSourceLines(err.Error()), ""+
+		"leaf error"+
+		"\n"+
+		"\nTraceback:"+
+		"\n  Factory for *gontainer.testFmtLeaf"+
+		"\n  Entrypoint"+
+		"\n"+
+		"\nsecond entrypoint error"+
+		"\n"+
+		"\nTraceback:"+
+		"\n  Entrypoint")
+}
+
+// TestErrorFormatIsMatchesSentinels verifies that errors.Is matches every documented sentinel.
+func TestErrorFormatIsMatchesSentinels(t *testing.T) {
+	t.Run("FactoryReturnedError", func(t *testing.T) {
+		err := Run(
+			NewFactory(func() (*testFmtLeaf, error) {
+				return nil, errors.New("boom")
+			}),
+			NewEntrypoint(func(*testFmtLeaf) {}),
+		)
+		equal(t, errors.Is(err, ErrFactoryReturnedError), true)
+	})
+
+	t.Run("EntrypointReturnedError", func(t *testing.T) {
+		err := Run(
+			NewEntrypoint(func() error {
+				return errors.New("boom")
+			}),
+		)
+		equal(t, errors.Is(err, ErrEntrypointReturnedError), true)
+	})
+
+	t.Run("DependencyNotResolved", func(t *testing.T) {
+		err := Run(
+			NewEntrypoint(func(*testFmtLeaf) {}),
+		)
+		equal(t, errors.Is(err, ErrDependencyNotResolved), true)
+	})
+
+	t.Run("CircularDependency", func(t *testing.T) {
+		err := Run(
+			NewFactory(func(*testFmtMid) *testFmtRootA { return &testFmtRootA{} }),
+			NewFactory(func(*testFmtRootA) *testFmtMid { return &testFmtMid{} }),
+			NewEntrypoint(func(*testFmtRootA) {}),
+		)
+		equal(t, errors.Is(err, ErrCircularDependency), true)
+	})
+
+	t.Run("FactoryTypeDuplicated", func(t *testing.T) {
+		err := Run(
+			NewFactory(func() *testFmtLeaf { return &testFmtLeaf{} }),
+			NewFactory(func() *testFmtLeaf { return &testFmtLeaf{} }),
+			NewEntrypoint(func(*testFmtLeaf) {}),
+		)
+		equal(t, errors.Is(err, ErrFactoryTypeDuplicated), true)
+	})
+}
+
+// TestErrorFormatAsUnwrapsToUserError verifies that errors.As reaches a caller-provided error type through the resolve chain.
+func TestErrorFormatAsUnwrapsToUserError(t *testing.T) {
+	cause := &testFmtTypedErr{msg: "custom user error"}
+
+	err := Run(
+		NewFactory(func() (*testFmtLeaf, error) {
+			return nil, cause
+		}),
+		NewFactory(func(*testFmtLeaf) *testFmtMid {
+			return &testFmtMid{}
+		}),
+		NewEntrypoint(func(*testFmtMid) error { return nil }),
+	)
+
+	equal(t, err != nil, true)
+
+	var target *testFmtTypedErr
+	equal(t, errors.As(err, &target), true)
+	equal(t, target.msg, "custom user error")
+}
+
+// TestErrorFormatMultipleTagsBothMatch checks that a dynamically resolved factory error keeps both inner and outer sentinels matchable.
+func TestErrorFormatMultipleTagsBothMatch(t *testing.T) {
+	err := Run(
+		NewFactory(func() (*testFmtLeaf, error) {
+			return nil, errors.New("leaf factory failed")
+		}),
+		NewEntrypoint(func(resolver *Resolver) error {
+			var leaf *testFmtLeaf
+			return resolver.Resolve(&leaf)
+		}),
+	)
+
+	equal(t, err != nil, true)
+	equal(t, errors.Is(err, ErrFactoryReturnedError), true)
+	equal(t, errors.Is(err, ErrEntrypointReturnedError), true)
+}
+
+// TestErrorFormatPlainMultiLineFallback checks that plain multi-line errors are reproduced verbatim, without bullet prefixes.
+func TestErrorFormatPlainMultiLineFallback(t *testing.T) {
+	multiLine := errors.New("first line\nsecond line\nthird line")
+
+	err := Run(
+		NewFactory(func() (*testFmtLeaf, error) {
+			return nil, multiLine
+		}),
+		NewEntrypoint(func(*testFmtLeaf) {}),
+	)
+
+	equal(t, err != nil, true)
+	equal(t, normalizeSourceLines(err.Error()), ""+
+		"first line"+
+		"\nsecond line"+
+		"\nthird line"+
+		"\n"+
+		"\nTraceback:"+
+		"\n  Factory for *gontainer.testFmtLeaf"+
+		"\n  Entrypoint")
+}
+
+// TestErrorFormatSourceLinesAreEmitted verifies every frame carries a distinct "    at <file>:<line>" meta line.
+func TestErrorFormatSourceLinesAreEmitted(t *testing.T) {
+	err := Run(
+		NewFactory(func() (*testFmtLeaf, error) {
+			return nil, errors.New("boom")
+		}),
+		NewFactory(func(*testFmtLeaf) *testFmtMid { return &testFmtMid{} }),
+		NewEntrypoint(func(*testFmtMid) {}),
+	)
+
+	equal(t, err != nil, true)
+
+	got := err.Error()
+
+	atRe := regexp.MustCompile(`\n {4}at ([^:\n]+):(\d+)`)
+	atMatches := atRe.FindAllStringSubmatch(got, -1)
+	equal(t, len(atMatches), 3)
+
+	seenLines := map[int]bool{}
+	for _, m := range atMatches {
+		if m[1] == "" {
+			t.Fatalf("expected non-empty file path in 'at' line")
+		}
+		line, convErr := strconv.Atoi(m[2])
+		equal(t, convErr, nil)
+		if line <= 0 {
+			t.Fatalf("expected positive line number, got %d", line)
+		}
+		seenLines[line] = true
+	}
+
+	if len(seenLines) != 3 {
+		t.Fatalf("expected 3 distinct source lines, got %d: %v", len(seenLines), seenLines)
+	}
+}
+
+// TestErrorFormatCloseSingle verifies that a single close failure renders as "<cause>\n\nSource:\n  Factory for <T>".
+func TestErrorFormatCloseSingle(t *testing.T) {
+	closeErr := errors.New("sync: file closed")
+
+	err := Run(
+		NewFactory(func() (*testFmtLeaf, func() error) {
+			return &testFmtLeaf{}, func() error { return closeErr }
+		}),
+		NewEntrypoint(func(*testFmtLeaf) {}),
+	)
+
+	equal(t, err != nil, true)
+	equal(t, normalizeSourceLines(err.Error()), ""+
+		"sync: file closed"+
+		"\n"+
+		"\nSource:"+
+		"\n  Factory for *gontainer.testFmtLeaf")
+	// The user's original error must still be reachable.
+	equal(t, errors.Is(err, closeErr), true)
+}
+
+// TestErrorFormatCloseMultiple verifies that multiple close failures render as independent blocks in reverse construction order.
+func TestErrorFormatCloseMultiple(t *testing.T) {
+	errLeaf := errors.New("leaf close failed")
+	errMid := errors.New("mid close failed")
+
+	err := Run(
+		NewFactory(func() (*testFmtLeaf, func() error) {
+			return &testFmtLeaf{}, func() error { return errLeaf }
+		}),
+		NewFactory(func(*testFmtLeaf) (*testFmtMid, func() error) {
+			return &testFmtMid{}, func() error { return errMid }
+		}),
+		NewEntrypoint(func(*testFmtMid) {}),
+	)
+
+	equal(t, err != nil, true)
+	// Shutdown order is reverse construction order: the entrypoint's
+	// dependency (*testFmtMid) closes first, then *testFmtLeaf.
+	equal(t, normalizeSourceLines(err.Error()), ""+
+		"mid close failed"+
+		"\n"+
+		"\nSource:"+
+		"\n  Factory for *gontainer.testFmtMid"+
+		"\n"+
+		"\nleaf close failed"+
+		"\n"+
+		"\nSource:"+
+		"\n  Factory for *gontainer.testFmtLeaf")
+	equal(t, errors.Is(err, errLeaf), true)
+	equal(t, errors.Is(err, errMid), true)
+}
+
+// TestErrorFormatCloseJoinCause verifies that a close error whose cause is an errors.Join renders inner errors as "- " bullets.
+func TestErrorFormatCloseJoinCause(t *testing.T) {
+	joined := fmt.Errorf("failed to close pool connections: %w", errors.Join(
+		errors.New("conn1: write: broken pipe"),
+		errors.New("conn2: context canceled"),
+	))
+
+	err := Run(
+		NewFactory(func() (*testFmtLeaf, func() error) {
+			return &testFmtLeaf{}, func() error { return joined }
+		}),
+		NewEntrypoint(func(*testFmtLeaf) {}),
+	)
+
+	equal(t, err != nil, true)
+	equal(t, normalizeSourceLines(err.Error()), ""+
+		"failed to close pool connections:"+
+		"\n- conn1: write: broken pipe"+
+		"\n- conn2: context canceled"+
+		"\n"+
+		"\nSource:"+
+		"\n  Factory for *gontainer.testFmtLeaf")
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -87,7 +87,7 @@ func TestErrorFormatDeepChainOneLineCause(t *testing.T) {
 	equal(t, errors.Is(err, ErrFactoryReturnedError), true)
 }
 
-// TestErrorFormatDeepChainJoinCause checks that an errors.Join cause renders each item as a "- " bullet.
+// TestErrorFormatDeepChainJoinCause checks that an errors.Join cause is rendered verbatim via err.Error().
 func TestErrorFormatDeepChainJoinCause(t *testing.T) {
 	joined := errors.Join(
 		errors.New("FIELD_A: 'required' rule failed"),
@@ -106,8 +106,8 @@ func TestErrorFormatDeepChainJoinCause(t *testing.T) {
 
 	equal(t, err != nil, true)
 	equal(t, normalizeSourceLines(err.Error()), ""+
-		"- FIELD_A: 'required' rule failed"+
-		"\n- FIELD_B: 'required' rule failed"+
+		"FIELD_A: 'required' rule failed"+
+		"\nFIELD_B: 'required' rule failed"+
 		"\n"+
 		"\nTraceback:"+
 		"\n  Factory for *gontainer.testFmtLeaf"+
@@ -116,7 +116,7 @@ func TestErrorFormatDeepChainJoinCause(t *testing.T) {
 	equal(t, errors.Is(err, ErrFactoryReturnedError), true)
 }
 
-// TestErrorFormatDeepChainWrapperOverJoin checks that a wrapper adds a header line above bullets from an inner Join.
+// TestErrorFormatDeepChainWrapperOverJoin checks that a wrapper over errors.Join is rendered verbatim.
 func TestErrorFormatDeepChainWrapperOverJoin(t *testing.T) {
 	joined := errors.Join(
 		errors.New("URL: 'required' rule failed"),
@@ -136,9 +136,8 @@ func TestErrorFormatDeepChainWrapperOverJoin(t *testing.T) {
 
 	equal(t, err != nil, true)
 	equal(t, normalizeSourceLines(err.Error()), ""+
-		"failed to load GitLab client config:"+
-		"\n- URL: 'required' rule failed"+
-		"\n- TOKEN: 'required' rule failed"+
+		"failed to load GitLab client config: URL: 'required' rule failed"+
+		"\nTOKEN: 'required' rule failed"+
 		"\n"+
 		"\nTraceback:"+
 		"\n  Factory for *gontainer.testFmtLeaf"+
@@ -419,7 +418,7 @@ func TestErrorFormatCloseMultiple(t *testing.T) {
 	equal(t, errors.Is(err, errMid), true)
 }
 
-// TestErrorFormatCloseJoinCause verifies that a close error whose cause is an errors.Join renders inner errors as "- " bullets.
+// TestErrorFormatCloseJoinCause verifies that a close error with a multi-line cause renders the cause verbatim.
 func TestErrorFormatCloseJoinCause(t *testing.T) {
 	joined := fmt.Errorf("failed to close pool connections: %w", errors.Join(
 		errors.New("conn1: write: broken pipe"),
@@ -435,9 +434,8 @@ func TestErrorFormatCloseJoinCause(t *testing.T) {
 
 	equal(t, err != nil, true)
 	equal(t, normalizeSourceLines(err.Error()), ""+
-		"failed to close pool connections:"+
-		"\n- conn1: write: broken pipe"+
-		"\n- conn2: context canceled"+
+		"failed to close pool connections: conn1: write: broken pipe"+
+		"\nconn2: context canceled"+
 		"\n"+
 		"\nSource:"+
 		"\n  Factory for *gontainer.testFmtLeaf")

--- a/factory.go
+++ b/factory.go
@@ -19,17 +19,9 @@ package gontainer
 
 import (
 	"reflect"
-	"runtime"
 	"strings"
 	"sync"
 )
-
-// getFuncSource returns func source path.
-func getFuncSource(funcValue reflect.Value) string {
-	fullFuncName := runtime.FuncForPC(funcValue.Pointer()).Name()
-	funcPackage, _ := splitFuncName(fullFuncName)
-	return funcPackage
-}
 
 // splitFuncName splits specified func name to package and a name.
 func splitFuncName(funcFullName string) (string, string) {

--- a/factory.go
+++ b/factory.go
@@ -55,7 +55,7 @@ func splitFuncName(funcFullName string) (string, string) {
 
 // newFactory loads factory function to the internal representation.
 func newFactory(
-	name, source string, funcValue reflect.Value,
+	kind factoryKind, name, source string, funcValue reflect.Value,
 	getOutType getOutTypeFn, getOutValue getOutValueFn,
 	getOutClose getOutCloseFn, getOutError getOutErrorFn,
 ) (*factory, error) {
@@ -76,6 +76,7 @@ func newFactory(
 
 	// Prepare registry factory instance.
 	return &factory{
+		kind:      kind,
 		name:      name,
 		source:    source,
 		funcType:  funcType,
@@ -91,8 +92,22 @@ func newFactory(
 	}, nil
 }
 
+// factoryKind defines a factory kind.
+type factoryKind int
+
+const (
+	// kindFactory is a regular service factory.
+	kindFactory factoryKind = iota
+
+	// kindEntrypoint is an entrypoint function.
+	kindEntrypoint
+)
+
 // factory is the factory internal representation.
 type factory struct {
+	// Factory kind.
+	kind factoryKind
+
 	// Factory func name.
 	name string
 

--- a/factory_test.go
+++ b/factory_test.go
@@ -20,6 +20,7 @@ package gontainer
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -56,31 +57,26 @@ func TestFactoryInfo(t *testing.T) {
 		name  string
 		arg1  *Factory
 		want1 string
-		want2 string
 	}{
 		{
 			name:  "ServiceLocalType",
 			arg1:  NewService(localType{}),
 			want1: "Service[gontainer.localType]",
-			want2: "github.com/NVIDIA/gontainer/v2",
 		},
 		{
 			name:  "ServiceGlobalType",
 			arg1:  NewService(globalType{}),
 			want1: "Service[gontainer.globalType]",
-			want2: "github.com/NVIDIA/gontainer/v2",
 		},
 		{
 			name:  "FactoryLocalFunc",
 			arg1:  NewFactory(localFunc),
 			want1: "Factory[func(gontainer.globalType) string]",
-			want2: "github.com/NVIDIA/gontainer/v2",
 		},
 		{
 			name:  "FactoryGlobalFunc",
 			arg1:  NewFactory(globalFunc),
 			want1: "Factory[func(string) bool]",
-			want2: "github.com/NVIDIA/gontainer/v2",
 		},
 	}
 	for _, tt := range tests {
@@ -90,7 +86,10 @@ func TestFactoryInfo(t *testing.T) {
 
 			factory := registry.factories[0]
 			equal(t, factory.name, tt.want1)
-			equal(t, factory.source, tt.want2)
+			// Source is now a clickable "<file>:<line>" location.
+			if !strings.Contains(factory.source, ".go:") {
+				t.Fatalf("expected file:line source, got %q", factory.source)
+			}
 		})
 	}
 }

--- a/registry.go
+++ b/registry.go
@@ -187,7 +187,7 @@ func (r *registry) closeFactories() error {
 
 		// Invoke close callback function.
 		if err := fact.getOutClose()(); err != nil {
-			errs = append(errs, errFactoryClose(fact, err))
+			errs = append(errs, errFactoryCloseFailed(fact, err))
 		}
 	}
 

--- a/registry.go
+++ b/registry.go
@@ -49,7 +49,7 @@ func (r *registry) registerEntrypoint(fact *factory) {
 // and for possible circular dependencies between factories.
 func (r *registry) validateRegistry() error {
 	// Prepare result errors accumulator.
-	var errs resolveErrors
+	var errs errorGroup
 
 	// Combine all factories and functions for validation.
 	allFactories := make([]*factory, 0, len(r.factories)+len(r.entrypoints))
@@ -149,7 +149,7 @@ func (r *registry) validateRegistry() error {
 // invokeEntrypoints invokes registered entrypoints.
 func (r *registry) invokeEntrypoints() error {
 	// Prepare result errors accumulator.
-	var errs resolveErrors
+	var errs errorGroup
 
 	// Invoke all functions in the registry.
 	for _, fact := range r.entrypoints {
@@ -179,7 +179,7 @@ func (r *registry) invokeEntrypoints() error {
 // closeFactories closes all factories in the reverse order.
 func (r *registry) closeFactories() error {
 	// Prepare result errors accumulator.
-	var errs closeErrors
+	var errs errorGroup
 
 	// Close all spawned factories in the reverse order.
 	for index := len(r.sequence) - 1; index >= 0; index-- {

--- a/registry.go
+++ b/registry.go
@@ -18,8 +18,6 @@
 package gontainer
 
 import (
-	"errors"
-	"fmt"
 	"reflect"
 	"sync"
 )
@@ -50,8 +48,8 @@ func (r *registry) registerEntrypoint(fact *factory) {
 // Validate checks for availability of all non-optional types
 // and for possible circular dependencies between factories.
 func (r *registry) validateRegistry() error {
-	// Prepare result errors slice.
-	var errs []error
+	// Prepare result errors accumulator.
+	var errs resolveErrors
 
 	// Combine all factories and functions for validation.
 	allFactories := make([]*factory, 0, len(r.factories)+len(r.entrypoints))
@@ -76,11 +74,7 @@ func (r *registry) validateRegistry() error {
 			// Could a factory for this type be resolved?
 			foundFactories := r.findFactories(inType)
 			if len(foundFactories) == 0 {
-				errs = append(errs, fmt.Errorf(
-					"%s from '%s': argument '%s': %w",
-					fact.name, fact.source, inType,
-					ErrDependencyNotResolved,
-				))
+				errs = append(errs, errDependencyNotResolved(fact, inType))
 				continue
 			}
 		}
@@ -99,18 +93,14 @@ func (r *registry) validateRegistry() error {
 		// Validate uniqueness of the factory output type.
 		factories := r.findFactories(outType)
 		if len(factories) > 1 {
-			errs = append(errs, fmt.Errorf(
-				"%s from '%s': output '%s': %w",
-				fact.name, fact.source, outType,
-				ErrFactoryTypeDuplicated,
-			))
+			errs = append(errs, errFactoryTypeDuplicated(fact))
 		}
 	}
 
 	// Validate for circular dependencies.
-	for index := range r.factories {
-		factories := []*factory{r.factories[index]}
-	recursion:
+	for _, fact := range r.factories {
+		factories := []*factory{fact}
+	iteration:
 		for len(factories) > 0 {
 			nextFact := factories[0]
 			factories = factories[1:]
@@ -131,14 +121,9 @@ func (r *registry) validateRegistry() error {
 				// Walk through all factories for this in argument type.
 				typeFactories := r.findFactories(inType)
 				for _, factoryForType := range typeFactories {
-					if factoryForType == r.factories[index] {
-						errs = append(errs, fmt.Errorf(
-							"%s from '%s': %w",
-							r.factories[index].name,
-							r.factories[index].source,
-							ErrCircularDependency,
-						))
-						break recursion
+					if factoryForType == fact {
+						errs = append(errs, errCircularDependency(fact))
+						break iteration
 					}
 				}
 
@@ -152,23 +137,25 @@ func (r *registry) validateRegistry() error {
 		errs = append(errs, ErrNoEntrypointsProvided)
 	}
 
-	// Join all found errors.
-	return errors.Join(errs...)
+	// Return nil if no errors found.
+	if len(errs) == 0 {
+		return nil
+	}
+
+	// Return collected errors.
+	return errs
 }
 
 // invokeEntrypoints invokes registered entrypoints.
 func (r *registry) invokeEntrypoints() error {
-	// Prepare result errors slice.
-	var errs []error
+	// Prepare result errors accumulator.
+	var errs resolveErrors
 
 	// Invoke all functions in the registry.
 	for _, fact := range r.entrypoints {
 		// Invoke the factory.
 		if err := r.invokeFactory(fact); err != nil {
-			errs = append(errs, fmt.Errorf(
-				"%s from '%s': invoke: %w",
-				fact.name, fact.source, err,
-			))
+			errs = append(errs, errFactoryResolveFailed(fact, err))
 
 			// The entrypoint was not invoked.
 			continue
@@ -176,22 +163,23 @@ func (r *registry) invokeEntrypoints() error {
 
 		// Handle factory error.
 		if err := fact.getOutError(); err != nil {
-			errs = append(errs, fmt.Errorf(
-				"%s from '%s': %w: %w",
-				fact.name, fact.source,
-				ErrEntrypointReturnedError, err,
-			))
+			errs = append(errs, errEntrypointReturnedError(fact, err))
 		}
 	}
 
-	// Join all found errors.
-	return errors.Join(errs...)
+	// Return nil if no errors found.
+	if len(errs) == 0 {
+		return nil
+	}
+
+	// Return collected errors.
+	return errs
 }
 
 // closeFactories closes all factories in the reverse order.
 func (r *registry) closeFactories() error {
-	// Prepare result errors slice.
-	var errs []error
+	// Prepare result errors accumulator.
+	var errs closeErrors
 
 	// Close all spawned factories in the reverse order.
 	for index := len(r.sequence) - 1; index >= 0; index-- {
@@ -199,15 +187,17 @@ func (r *registry) closeFactories() error {
 
 		// Invoke close callback function.
 		if err := fact.getOutClose()(); err != nil {
-			errs = append(errs, fmt.Errorf(
-				"%s from '%s': close: %w",
-				fact.name, fact.source, err,
-			))
+			errs = append(errs, errFactoryClose(fact, err))
 		}
 	}
 
-	// Join all found errors.
-	return errors.Join(errs...)
+	// Return nil if no errors found.
+	if len(errs) == 0 {
+		return nil
+	}
+
+	// Return collected errors.
+	return errs
 }
 
 // resolveService resolves and returns the service based on the type.
@@ -230,6 +220,7 @@ func (r *registry) resolveService(serviceType reflect.Type) (reflect.Value, erro
 
 // resolveOptional resolves a service wrapped with an optional type.
 func (r *registry) resolveOptional(optionalType, serviceType reflect.Type) (reflect.Value, error) {
+	// Resolve all services by specified type.
 	serviceValues, err := r.resolveByType(serviceType)
 	if err != nil {
 		return reflect.Value{}, err
@@ -252,10 +243,13 @@ func (r *registry) resolveOptional(optionalType, serviceType reflect.Type) (refl
 
 // resolveMultiple resolves all services fits to the multiple type.
 func (r *registry) resolveMultiple(multipleType, serviceType reflect.Type) (reflect.Value, error) {
+	// Resolve all services by specified type.
 	serviceValues, err := r.resolveByType(serviceType)
 	if err != nil {
 		return reflect.Value{}, err
 	}
+
+	// Return resolved services in a multiple box type.
 	return newMultipleValue(multipleType, serviceValues), nil
 }
 
@@ -273,7 +267,7 @@ func (r *registry) resolveRegular(serviceType reflect.Type) (reflect.Value, erro
 	// unregistered type `Config` triggers an error, while resolving `gontainer.Optional[Config]`
 	// returns a zero-value box.
 	if len(resolvedValues) == 0 {
-		return reflect.Value{}, fmt.Errorf("%w: '%s'", ErrDependencyNotResolved, serviceType)
+		return reflect.Value{}, errDependencyNotResolved(nil, serviceType)
 	}
 
 	// Pick first found service value.
@@ -284,36 +278,33 @@ func (r *registry) resolveRegular(serviceType reflect.Type) (reflect.Value, erro
 func (r *registry) resolveByType(serviceType reflect.Type) ([]reflect.Value, error) {
 	// Lookup factory definition by an output type.
 	factories := r.findFactories(serviceType)
-	resolvedValues := make([]reflect.Value, 0, len(factories))
+
+	// Prepare result values slice.
+	results := make([]reflect.Value, 0, len(factories))
 
 	// Spawn all found factories.
 	for _, fact := range factories {
 		// Handle found factory definition.
 		if err := r.spawnFactory(fact); err != nil {
-			return nil, fmt.Errorf(
-				"%s from '%s': spawn: %w",
-				fact.name, fact.source, err,
-			)
+			return nil, errFactoryResolveFailed(fact, err)
 		}
 
 		// Handle error returned by the factory.
 		if err := fact.getOutError(); err != nil {
-			return nil, fmt.Errorf(
-				"%s from '%s': %w: %w",
-				fact.name, fact.source,
-				ErrFactoryReturnedError, err,
-			)
+			return nil, errFactoryReturnedError(fact, err)
 		}
 
 		// Handle the factory result output.
-		resolvedValues = append(resolvedValues, fact.getOutValue())
+		results = append(results, fact.getOutValue())
 	}
 
-	return resolvedValues, nil
+	// Return resolved values.
+	return results, nil
 }
 
 // findFactories lookups for all factories for an output type in the registry.
 func (r *registry) findFactories(serviceType reflect.Type) []*factory {
+	// Prepare result factories slice.
 	var factories []*factory
 
 	// Lookup for factories in the registry.
@@ -369,6 +360,7 @@ func (r *registry) spawnFactory(fact *factory) error {
 	r.sequence = append(r.sequence, fact)
 	r.mutex.Unlock()
 
+	// Factory spawned successfully.
 	return nil
 }
 

--- a/registry.go
+++ b/registry.go
@@ -33,17 +33,17 @@ type registry struct {
 }
 
 // registerFactory registers factory function in the registry.
-func (r *registry) registerFactory(factory *factory) {
+func (r *registry) registerFactory(fact *factory) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
-	r.factories = append(r.factories, factory)
+	r.factories = append(r.factories, fact)
 }
 
 // registerEntrypoint registers entrypoint function in the registry.
-func (r *registry) registerEntrypoint(factory *factory) {
+func (r *registry) registerEntrypoint(fact *factory) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
-	r.entrypoints = append(r.entrypoints, factory)
+	r.entrypoints = append(r.entrypoints, fact)
 }
 
 // validateRegistry validates all registered state.
@@ -59,8 +59,8 @@ func (r *registry) validateRegistry() error {
 	allFactories = append(allFactories, r.entrypoints...)
 
 	// Validate all input types are resolvable.
-	for _, factory := range allFactories {
-		for _, inType := range factory.inTypes {
+	for _, fact := range allFactories {
+		for _, inType := range fact.inTypes {
 			// Is this type wrapped to the `Optional[type]`?
 			_, isOptional := isOptionalType(inType)
 			if isOptional {
@@ -78,7 +78,7 @@ func (r *registry) validateRegistry() error {
 			if len(foundFactories) == 0 {
 				errs = append(errs, fmt.Errorf(
 					"%s from '%s': argument '%s': %w",
-					factory.name, factory.source, inType,
+					fact.name, fact.source, inType,
 					ErrDependencyNotResolved,
 				))
 				continue
@@ -87,9 +87,9 @@ func (r *registry) validateRegistry() error {
 	}
 
 	// Validate all output types are unique.
-	for _, factory := range r.factories {
+	for _, fact := range r.factories {
 		// Prepare factory output type.
-		outType := factory.getOutType()
+		outType := fact.getOutType()
 
 		// Skip factories without output type.
 		if outType == nil {
@@ -101,7 +101,7 @@ func (r *registry) validateRegistry() error {
 		if len(factories) > 1 {
 			errs = append(errs, fmt.Errorf(
 				"%s from '%s': output '%s': %w",
-				factory.name, factory.source, outType,
+				fact.name, fact.source, outType,
 				ErrFactoryTypeDuplicated,
 			))
 		}
@@ -112,10 +112,10 @@ func (r *registry) validateRegistry() error {
 		factories := []*factory{r.factories[index]}
 	recursion:
 		for len(factories) > 0 {
-			factory := factories[0]
+			nextFact := factories[0]
 			factories = factories[1:]
 
-			for _, inType := range factory.inTypes {
+			for _, inType := range nextFact.inTypes {
 				// Is this type wrapped to the `Optional[type]`?
 				innerType, isOptional := isOptionalType(inType)
 				if isOptional {
@@ -162,12 +162,12 @@ func (r *registry) invokeEntrypoints() error {
 	var errs []error
 
 	// Invoke all functions in the registry.
-	for _, factory := range r.entrypoints {
+	for _, fact := range r.entrypoints {
 		// Invoke the factory.
-		if err := r.invokeFactory(factory); err != nil {
+		if err := r.invokeFactory(fact); err != nil {
 			errs = append(errs, fmt.Errorf(
 				"%s from '%s': invoke: %w",
-				factory.name, factory.source, err,
+				fact.name, fact.source, err,
 			))
 
 			// The entrypoint was not invoked.
@@ -175,10 +175,10 @@ func (r *registry) invokeEntrypoints() error {
 		}
 
 		// Handle factory error.
-		if err := factory.getOutError(); err != nil {
+		if err := fact.getOutError(); err != nil {
 			errs = append(errs, fmt.Errorf(
 				"%s from '%s': %w: %w",
-				factory.name, factory.source,
+				fact.name, fact.source,
 				ErrEntrypointReturnedError, err,
 			))
 		}
@@ -195,13 +195,13 @@ func (r *registry) closeFactories() error {
 
 	// Close all spawned factories in the reverse order.
 	for index := len(r.sequence) - 1; index >= 0; index-- {
-		factory := r.sequence[index]
+		fact := r.sequence[index]
 
 		// Invoke close callback function.
-		if err := factory.getOutClose()(); err != nil {
+		if err := fact.getOutClose()(); err != nil {
 			errs = append(errs, fmt.Errorf(
 				"%s from '%s': close: %w",
-				factory.name, factory.source, err,
+				fact.name, fact.source, err,
 			))
 		}
 	}
@@ -287,26 +287,26 @@ func (r *registry) resolveByType(serviceType reflect.Type) ([]reflect.Value, err
 	resolvedValues := make([]reflect.Value, 0, len(factories))
 
 	// Spawn all found factories.
-	for _, factory := range factories {
+	for _, fact := range factories {
 		// Handle found factory definition.
-		if err := r.spawnFactory(factory); err != nil {
+		if err := r.spawnFactory(fact); err != nil {
 			return nil, fmt.Errorf(
 				"%s from '%s': spawn: %w",
-				factory.name, factory.source, err,
+				fact.name, fact.source, err,
 			)
 		}
 
 		// Handle error returned by the factory.
-		if err := factory.getOutError(); err != nil {
+		if err := fact.getOutError(); err != nil {
 			return nil, fmt.Errorf(
 				"%s from '%s': %w: %w",
-				factory.name, factory.source,
+				fact.name, fact.source,
 				ErrFactoryReturnedError, err,
 			)
 		}
 
 		// Handle the factory result output.
-		resolvedValues = append(resolvedValues, factory.getOutValue())
+		resolvedValues = append(resolvedValues, fact.getOutValue())
 	}
 
 	return resolvedValues, nil
@@ -317,8 +317,8 @@ func (r *registry) findFactories(serviceType reflect.Type) []*factory {
 	var factories []*factory
 
 	// Lookup for factories in the registry.
-	for _, factory := range r.factories {
-		outType := factory.getOutType()
+	for _, fact := range r.factories {
+		outType := fact.getOutType()
 
 		// Skip factories without an output type.
 		if outType == nil {
@@ -327,14 +327,14 @@ func (r *registry) findFactories(serviceType reflect.Type) []*factory {
 
 		// Desired service type matched.
 		if outType == serviceType {
-			factories = append(factories, factory)
+			factories = append(factories, fact)
 			continue
 		}
 
 		// Desired service type implements an interface.
 		if serviceType.Kind() == reflect.Interface {
 			if outType.Implements(serviceType) {
-				factories = append(factories, factory)
+				factories = append(factories, fact)
 				continue
 			}
 		}
@@ -345,38 +345,38 @@ func (r *registry) findFactories(serviceType reflect.Type) []*factory {
 }
 
 // spawnFactory instantiates specified factory definition.
-func (r *registry) spawnFactory(factory *factory) error {
+func (r *registry) spawnFactory(fact *factory) error {
 	// Lock the factory spawn mutex.
-	factory.spawnMu.Lock()
-	defer factory.spawnMu.Unlock()
+	fact.spawnMu.Lock()
+	defer fact.spawnMu.Unlock()
 
 	// Check factory already spawned.
-	if factory.getIsSpawned() {
+	if fact.getIsSpawned() {
 		return nil
 	}
 
 	// Invoke the factory.
-	err := r.invokeFactory(factory)
+	err := r.invokeFactory(fact)
 	if err != nil {
 		return err
 	}
 
 	// Save the factory spawn status.
-	factory.setIsSpawned(true)
+	fact.setIsSpawned(true)
 
 	// Save the factory spawn order.
 	r.mutex.Lock()
-	r.sequence = append(r.sequence, factory)
+	r.sequence = append(r.sequence, fact)
 	r.mutex.Unlock()
 
 	return nil
 }
 
 // invokeFactory calls the factory function and returns output values.
-func (r *registry) invokeFactory(factory *factory) error {
+func (r *registry) invokeFactory(fact *factory) error {
 	// Get or spawn factory input values recursively.
-	inValues := make([]reflect.Value, 0, len(factory.inTypes))
-	for _, inType := range factory.inTypes {
+	inValues := make([]reflect.Value, 0, len(fact.inTypes))
+	for _, inType := range fact.inTypes {
 		// Resolve factory input dependency.
 		inValue, err := r.resolveService(inType)
 		if err != nil {
@@ -388,10 +388,10 @@ func (r *registry) invokeFactory(factory *factory) error {
 	}
 
 	// Call the factory using input arguments.
-	outValues := factory.funcValue.Call(inValues)
+	outValues := fact.funcValue.Call(inValues)
 
 	// Set factory output values.
-	factory.setOutValues(outValues)
+	fact.setOutValues(outValues)
 
 	// Factory invoked successfully.
 	return nil

--- a/registry.go
+++ b/registry.go
@@ -380,7 +380,7 @@ func (r *registry) invokeFactory(factory *factory) error {
 		// Resolve factory input dependency.
 		inValue, err := r.resolveService(inType)
 		if err != nil {
-			return fmt.Errorf("failed to resolve service: %w", err)
+			return err
 		}
 
 		// Append resolved input value.

--- a/registry.go
+++ b/registry.go
@@ -54,12 +54,12 @@ func (r *registry) validateRegistry() error {
 	var errs []error
 
 	// Combine all factories and functions for validation.
-	factories := make([]*factory, 0, len(r.factories)+len(r.entrypoints))
-	factories = append(factories, r.factories...)
-	factories = append(factories, r.entrypoints...)
+	allFactories := make([]*factory, 0, len(r.factories)+len(r.entrypoints))
+	allFactories = append(allFactories, r.factories...)
+	allFactories = append(allFactories, r.entrypoints...)
 
 	// Validate all input types are resolvable.
-	for _, factory := range factories {
+	for _, factory := range allFactories {
 		for _, inType := range factory.inTypes {
 			// Is this type wrapped to the `Optional[type]`?
 			_, isOptional := isOptionalType(inType)
@@ -74,8 +74,8 @@ func (r *registry) validateRegistry() error {
 			}
 
 			// Could a factory for this type be resolved?
-			factories := r.findFactories(inType)
-			if len(factories) == 0 {
+			foundFactories := r.findFactories(inType)
+			if len(foundFactories) == 0 {
 				errs = append(errs, fmt.Errorf(
 					"%s from '%s': argument '%s': %w",
 					factory.name, factory.source, inType,

--- a/registry.go
+++ b/registry.go
@@ -74,7 +74,7 @@ func (r *registry) validateRegistry() error {
 			// Could a factory for this type be resolved?
 			foundFactories := r.findFactories(inType)
 			if len(foundFactories) == 0 {
-				errs = append(errs, errDependencyNotResolved(fact, inType))
+				errs = append(errs, newDependencyNotResolvedError(fact, inType))
 				continue
 			}
 		}
@@ -93,7 +93,7 @@ func (r *registry) validateRegistry() error {
 		// Validate uniqueness of the factory output type.
 		factories := r.findFactories(outType)
 		if len(factories) > 1 {
-			errs = append(errs, errFactoryTypeDuplicated(fact))
+			errs = append(errs, newFactoryTypeDuplicatedError(fact))
 		}
 	}
 
@@ -122,7 +122,7 @@ func (r *registry) validateRegistry() error {
 				typeFactories := r.findFactories(inType)
 				for _, factoryForType := range typeFactories {
 					if factoryForType == fact {
-						errs = append(errs, errCircularDependency(fact))
+						errs = append(errs, newCircularDependencyError(fact))
 						break iteration
 					}
 				}
@@ -155,7 +155,7 @@ func (r *registry) invokeEntrypoints() error {
 	for _, fact := range r.entrypoints {
 		// Invoke the factory.
 		if err := r.invokeFactory(fact); err != nil {
-			errs = append(errs, errFactoryResolveFailed(fact, err))
+			errs = append(errs, newFactoryResolveFailedError(fact, err))
 
 			// The entrypoint was not invoked.
 			continue
@@ -163,7 +163,7 @@ func (r *registry) invokeEntrypoints() error {
 
 		// Handle factory error.
 		if err := fact.getOutError(); err != nil {
-			errs = append(errs, errEntrypointReturnedError(fact, err))
+			errs = append(errs, newEntrypointReturnedErrorError(fact, err))
 		}
 	}
 
@@ -187,7 +187,7 @@ func (r *registry) closeFactories() error {
 
 		// Invoke close callback function.
 		if err := fact.getOutClose()(); err != nil {
-			errs = append(errs, errFactoryCloseFailed(fact, err))
+			errs = append(errs, newFactoryCloseFailedError(fact, err))
 		}
 	}
 
@@ -267,7 +267,7 @@ func (r *registry) resolveRegular(serviceType reflect.Type) (reflect.Value, erro
 	// unregistered type `Config` triggers an error, while resolving `gontainer.Optional[Config]`
 	// returns a zero-value box.
 	if len(resolvedValues) == 0 {
-		return reflect.Value{}, errDependencyNotResolved(nil, serviceType)
+		return reflect.Value{}, newDependencyNotResolvedError(nil, serviceType)
 	}
 
 	// Pick first found service value.
@@ -286,12 +286,12 @@ func (r *registry) resolveByType(serviceType reflect.Type) ([]reflect.Value, err
 	for _, fact := range factories {
 		// Handle found factory definition.
 		if err := r.spawnFactory(fact); err != nil {
-			return nil, errFactoryResolveFailed(fact, err)
+			return nil, newFactoryResolveFailedError(fact, err)
 		}
 
 		// Handle error returned by the factory.
 		if err := fact.getOutError(); err != nil {
-			return nil, errFactoryReturnedError(fact, err)
+			return nil, newFactoryReturnedErrorError(fact, err)
 		}
 
 		// Handle the factory result output.

--- a/registry_test.go
+++ b/registry_test.go
@@ -76,14 +76,16 @@ func TestRegistryValidateFactories(t *testing.T) {
 				equal(t, len(errs), 2)
 
 				equal(t, errors.Is(errs[0], ErrDependencyNotResolved), true)
-				equal(t, errs[0].Error(), ""+
-					"Factory[func(bool) (int, error)] from 'github.com/NVIDIA/gontainer/v2': "+
-					"argument 'bool': dependency not resolved")
+				equal(t, normalizeSourceLines(errs[0].Error()), ""+
+					"dependency not resolved: bool\n\n"+
+					"Traceback:\n"+
+					"  Factory for int")
 
 				equal(t, errors.Is(errs[1], ErrDependencyNotResolved), true)
-				equal(t, errs[1].Error(), ""+
-					"Factory[func(string) (int32, error)] from 'github.com/NVIDIA/gontainer/v2': "+
-					"argument 'string': dependency not resolved")
+				equal(t, normalizeSourceLines(errs[1].Error()), ""+
+					"dependency not resolved: string\n\n"+
+					"Traceback:\n"+
+					"  Factory for int32")
 			},
 		},
 		{
@@ -102,14 +104,16 @@ func TestRegistryValidateFactories(t *testing.T) {
 				equal(t, len(errs), 2)
 
 				equal(t, errors.Is(errs[0], ErrFactoryTypeDuplicated), true)
-				equal(t, errs[0].Error(), ""+
-					"Factory[func() (string, error)] from 'github.com/NVIDIA/gontainer/v2': "+
-					"output 'string': factory type duplicated")
+				equal(t, normalizeSourceLines(errs[0].Error()), ""+
+					"factory type duplicated: string\n\n"+
+					"Traceback:\n"+
+					"  Factory for string")
 
 				equal(t, errors.Is(errs[1], ErrFactoryTypeDuplicated), true)
-				equal(t, errs[1].Error(), ""+
-					"Factory[func() (string, error)] from 'github.com/NVIDIA/gontainer/v2': "+
-					"output 'string': factory type duplicated")
+				equal(t, normalizeSourceLines(errs[1].Error()), ""+
+					"factory type duplicated: string\n\n"+
+					"Traceback:\n"+
+					"  Factory for string")
 			},
 		},
 		{
@@ -129,19 +133,22 @@ func TestRegistryValidateFactories(t *testing.T) {
 				equal(t, len(errs), 3)
 
 				equal(t, errors.Is(errs[0], ErrCircularDependency), true)
-				equal(t, errs[0].Error(), ""+
-					"Factory[func(bool) (int, error)] from 'github.com/NVIDIA/gontainer/v2': "+
-					"circular dependency")
+				equal(t, normalizeSourceLines(errs[0].Error()), ""+
+					"circular dependency\n\n"+
+					"Traceback:\n"+
+					"  Factory for int")
 
 				equal(t, errors.Is(errs[1], ErrCircularDependency), true)
-				equal(t, errs[1].Error(), ""+
-					"Factory[func(string) (bool, error)] from 'github.com/NVIDIA/gontainer/v2': "+
-					"circular dependency")
+				equal(t, normalizeSourceLines(errs[1].Error()), ""+
+					"circular dependency\n\n"+
+					"Traceback:\n"+
+					"  Factory for bool")
 
 				equal(t, errors.Is(errs[2], ErrCircularDependency), true)
-				equal(t, errs[2].Error(), ""+
-					"Factory[func(int) (string, error)] from 'github.com/NVIDIA/gontainer/v2': "+
-					"circular dependency")
+				equal(t, normalizeSourceLines(errs[2].Error()), ""+
+					"circular dependency\n\n"+
+					"Traceback:\n"+
+					"  Factory for string")
 			},
 		},
 		{
@@ -164,34 +171,40 @@ func TestRegistryValidateFactories(t *testing.T) {
 				equal(t, len(errs), 6)
 
 				equal(t, errors.Is(errs[0], ErrDependencyNotResolved), true)
-				equal(t, errs[0].Error(), ""+
-					"Factory[func(struct { X int }) string] from 'github.com/NVIDIA/gontainer/v2': "+
-					"argument 'struct { X int }': dependency not resolved")
+				equal(t, normalizeSourceLines(errs[0].Error()), ""+
+					"dependency not resolved: struct { X int }\n\n"+
+					"Traceback:\n"+
+					"  Factory for string")
 
 				equal(t, errors.Is(errs[1], ErrDependencyNotResolved), true)
-				equal(t, errs[1].Error(), ""+
-					"Entrypoint[func(struct { X int }) error] from 'github.com/NVIDIA/gontainer/v2': "+
-					"argument 'struct { X int }': dependency not resolved")
+				equal(t, normalizeSourceLines(errs[1].Error()), ""+
+					"dependency not resolved: struct { X int }\n\n"+
+					"Traceback:\n"+
+					"  Entrypoint")
 
 				equal(t, errors.Is(errs[2], ErrFactoryTypeDuplicated), true)
-				equal(t, errs[2].Error(), ""+
-					"Factory[func(struct { X int }) string] from 'github.com/NVIDIA/gontainer/v2': "+
-					"output 'string': factory type duplicated")
+				equal(t, normalizeSourceLines(errs[2].Error()), ""+
+					"factory type duplicated: string\n\n"+
+					"Traceback:\n"+
+					"  Factory for string")
 
 				equal(t, errors.Is(errs[3], ErrFactoryTypeDuplicated), true)
-				equal(t, errs[3].Error(), ""+
-					"Factory[func() string] from 'github.com/NVIDIA/gontainer/v2': "+
-					"output 'string': factory type duplicated")
+				equal(t, normalizeSourceLines(errs[3].Error()), ""+
+					"factory type duplicated: string\n\n"+
+					"Traceback:\n"+
+					"  Factory for string")
 
 				equal(t, errors.Is(errs[4], ErrCircularDependency), true)
-				equal(t, errs[4].Error(), ""+
-					"Factory[func(bool) (int, error)] from 'github.com/NVIDIA/gontainer/v2': "+
-					"circular dependency")
+				equal(t, normalizeSourceLines(errs[4].Error()), ""+
+					"circular dependency\n\n"+
+					"Traceback:\n"+
+					"  Factory for int")
 
 				equal(t, errors.Is(errs[5], ErrCircularDependency), true)
-				equal(t, errs[5].Error(), ""+
-					"Factory[func(int) (bool, error)] from 'github.com/NVIDIA/gontainer/v2': "+
-					"circular dependency")
+				equal(t, normalizeSourceLines(errs[5].Error()), ""+
+					"circular dependency\n\n"+
+					"Traceback:\n"+
+					"  Factory for bool")
 			},
 		},
 	}
@@ -314,9 +327,10 @@ func TestRegistryResolveWithErrors(t *testing.T) {
 	value, err := registry.resolveService(reflect.TypeOf(true))
 	equal(t, err != nil, true)
 	equal(t, value.IsValid(), false)
-	equal(t, fmt.Sprint(err), ""+
-		"Factory[func() (bool, error)] from 'github.com/NVIDIA/gontainer/v2': "+
-		"factory returned error: some function-specific error message")
+	equal(t, normalizeSourceLines(fmt.Sprint(err)), ""+
+		"some function-specific error message\n\n"+
+		"Traceback:\n"+
+		"  Factory for bool")
 	equal(t, errors.Is(err, ErrFactoryReturnedError), true)
 }
 
@@ -331,9 +345,10 @@ func TestRegistryInvokeWithErrors(t *testing.T) {
 
 	err := registry.invokeEntrypoints()
 	equal(t, err != nil, true)
-	equal(t, fmt.Sprint(err), ""+
-		"Entrypoint[func() error] from 'github.com/NVIDIA/gontainer/v2': "+
-		"entrypoint returned error: some function-specific error message")
+	equal(t, normalizeSourceLines(fmt.Sprint(err)), ""+
+		"some function-specific error message\n\n"+
+		"Traceback:\n"+
+		"  Entrypoint")
 	equal(t, errors.Is(err, ErrEntrypointReturnedError), true)
 }
 
@@ -355,11 +370,11 @@ func TestRegistryInvokeEntrypointWithFailedDependency(t *testing.T) {
 	err := registry.invokeEntrypoints()
 	equal(t, err != nil, true)
 	equal(t, errors.Is(err, ErrFactoryReturnedError), true)
-	equal(t, fmt.Sprint(err), ""+
-		"Entrypoint[func(string) error] from 'github.com/NVIDIA/gontainer/v2': "+
-		"invoke: failed to resolve service: "+
-		"Factory[func() (string, error)] from 'github.com/NVIDIA/gontainer/v2': "+
-		"factory returned error: dependency factory error")
+	equal(t, normalizeSourceLines(fmt.Sprint(err)), ""+
+		"dependency factory error\n\n"+
+		"Traceback:\n"+
+		"  Factory for string\n"+
+		"  Entrypoint")
 }
 
 // TestRegistryInvokeMultipleEntrypointsWithFailedDependency tests that a failed
@@ -393,14 +408,15 @@ func TestRegistryInvokeMultipleEntrypointsWithFailedDependency(t *testing.T) {
 	equal(t, ok, true)
 	errs := unwrap.Unwrap()
 	equal(t, len(errs), 2)
-	equal(t, errs[0].Error(), ""+
-		"Entrypoint[func(string) error] from 'github.com/NVIDIA/gontainer/v2': "+
-		"invoke: failed to resolve service: "+
-		"Factory[func() (string, error)] from 'github.com/NVIDIA/gontainer/v2': "+
-		"factory returned error: dependency factory error")
-	equal(t, errs[1].Error(), ""+
-		"Entrypoint[func() error] from 'github.com/NVIDIA/gontainer/v2': "+
-		"entrypoint returned error: second entrypoint error")
+	equal(t, normalizeSourceLines(errs[0].Error()), ""+
+		"dependency factory error\n\n"+
+		"Traceback:\n"+
+		"  Factory for string\n"+
+		"  Entrypoint")
+	equal(t, normalizeSourceLines(errs[1].Error()), ""+
+		"second entrypoint error\n\n"+
+		"Traceback:\n"+
+		"  Entrypoint")
 }
 
 // TestIsEmptyInterface tests checking of argument to be empty interface.


### PR DESCRIPTION
# Improved error format

This change introduces a new error rendering format for the container.
Errors are now presented as a structured traceback with the root cause
on the first line, followed by the resolution frames annotated with
`file:line` references.

## Examples

A factory returning an error:

```
boom

Traceback:
  Factory for *gontainer.testFmtLeaf
    at /path/to/file.go:47
  Entrypoint
    at /path/to/file.go:50
```

Unresolved dependency:

```
dependency not resolved: *gontainer.testFmtLeaf

Traceback:
  Entrypoint
    at /path/to/file.go:50
```

Multiple independent close errors:

```
close failed A

Source:
  Factory for *gontainer.testFmtLeaf
    at /path/to/file.go:47

close failed B

Source:
  Factory for *gontainer.testFmtMid
    at /path/to/file.go:52
```
