### PR TITLE
fix: keep cycle validation finite with a visited set

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -100,10 +100,16 @@ func (r *registry) validateRegistry() error {
 	// Validate for circular dependencies.
 	for _, fact := range r.factories {
 		factories := []*factory{fact}
+		visited := make(map[*factory]bool)
 	iteration:
 		for len(factories) > 0 {
 			nextFact := factories[0]
 			factories = factories[1:]
+
+			if visited[nextFact] {
+				continue
+			}
+			visited[nextFact] = true
 
 			for _, inType := range nextFact.inTypes {
 				// Is this type wrapped to the `Optional[type]`?

--- a/registry_test.go
+++ b/registry_test.go
@@ -219,6 +219,42 @@ func TestRegistryValidateFactories(t *testing.T) {
 	}
 }
 
+// cycA, cycB and cycC model a dependency graph where an acyclic factory (cycA)
+// can reach a cycle (cycB <-> cycC) that does not include it.
+type (
+	cycA int
+	cycB int
+	cycC int
+)
+
+// TestRegistryValidateCycle ensures cycle validation terminates properly.
+func TestRegistryValidateCycle(t *testing.T) {
+	registry := &registry{}
+	options := []Option{
+		// Acyclic root, registered first, depends on the cycle below.
+		NewFactory(func(cycB) cycA { return 0 }),
+
+		// cycB and cycC form a cycle that does not involve cycA.
+		NewFactory(func(cycC) cycB { return 0 }),
+		NewFactory(func(cycB) cycC { return 0 }),
+
+		NewEntrypoint(func(cycA) {}),
+	}
+	for _, option := range options {
+		equal(t, option.apply(registry), nil)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- registry.validateRegistry() }()
+
+	select {
+	case err := <-done:
+		equal(t, errors.Is(err, ErrCircularDependency), true)
+	case <-time.After(5 * time.Second):
+		t.Fatal("validateRegistry did not terminate: the cycle walk looped")
+	}
+}
+
 // TestRegistryInvokeFunctions tests corresponding registry method.
 func TestRegistryInvokeFunctions(t *testing.T) {
 	registry := &registry{}


### PR DESCRIPTION
Walk each factory's transitive dependencies breadth-first and track expanded factories in a visited set. A cycle reachable from an acyclic root previously looped forever; now every factory is expanded once. Add a regression test.