### PR TITLE
fix: spawn only the first implementation for regular interface deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,32 @@ gontainer.NewFactory(func(middlewares gontainer.Multiple[Middleware]) *Router {
 })
 ```
 
+### Interface Dependencies
+
+A factory can depend on an interface, and the container injects a registered
+service that implements it:
+
+```go
+type Store interface {
+    Get(key string) (string, bool)
+}
+
+gontainer.NewFactory(func() *MemoryStore {
+    return &MemoryStore{} // implements Store
+})
+
+gontainer.NewFactory(func(store Store) *API {
+    return &API{store: store}
+})
+```
+
+> **When several services implement the same interface, a regular dependency
+> resolves to the _first one in registration order_, and only that
+> implementation is spawned - others are left untouched.** This is by
+> design: it keeps regular resolution deterministic and free of side effects.
+> To receive every implementation, depend on
+> [`Multiple[T]`](#multiple-dependencies) instead.
+
 ### Multiple Instances of the Same Type
 
 The container matches services by exact type. To register several instances

--- a/registry.go
+++ b/registry.go
@@ -259,9 +259,7 @@ func (r *registry) resolveMultiple(multipleType, serviceType reflect.Type) (refl
 	return newMultipleValue(multipleType, serviceValues), nil
 }
 
-// resolveRegular resolves a regular (non-optional, non-multiple) service. For an
-// interface type with several registered implementations, the first one in
-// registration order is returned by design, and only that implementation is spawned.
+// resolveRegular resolves a regular (non-optional, non-multiple) service.
 func (r *registry) resolveRegular(serviceType reflect.Type) (reflect.Value, error) {
 	// Resolve the first matching service by a specified type.
 	resolvedValues, err := r.resolveByType(serviceType, false)

--- a/registry.go
+++ b/registry.go
@@ -220,8 +220,9 @@ func (r *registry) resolveService(serviceType reflect.Type) (reflect.Value, erro
 
 // resolveOptional resolves a service wrapped with an optional type.
 func (r *registry) resolveOptional(optionalType, serviceType reflect.Type) (reflect.Value, error) {
-	// Resolve all services by specified type.
-	serviceValues, err := r.resolveByType(serviceType)
+	// Resolve the service by specified type. Only the first matching factory is
+	// spawned; optional resolution never instantiates additional implementations.
+	serviceValues, err := r.resolveByType(serviceType, false)
 	if err != nil {
 		return reflect.Value{}, err
 	}
@@ -243,8 +244,8 @@ func (r *registry) resolveOptional(optionalType, serviceType reflect.Type) (refl
 
 // resolveMultiple resolves all services fits to the multiple type.
 func (r *registry) resolveMultiple(multipleType, serviceType reflect.Type) (reflect.Value, error) {
-	// Resolve all services by specified type.
-	serviceValues, err := r.resolveByType(serviceType)
+	// Resolve all services by specified type; Multiple spawns every match.
+	serviceValues, err := r.resolveByType(serviceType, true)
 	if err != nil {
 		return reflect.Value{}, err
 	}
@@ -253,10 +254,12 @@ func (r *registry) resolveMultiple(multipleType, serviceType reflect.Type) (refl
 	return newMultipleValue(multipleType, serviceValues), nil
 }
 
-// resolveRegular resolves a regular service.
+// resolveRegular resolves a regular (non-optional, non-multiple) service. For an
+// interface type with several registered implementations, the first one in
+// registration order is returned by design, and only that implementation is spawned.
 func (r *registry) resolveRegular(serviceType reflect.Type) (reflect.Value, error) {
-	// Resolve all services by specified type.
-	resolvedValues, err := r.resolveByType(serviceType)
+	// Resolve the service by specified type.
+	resolvedValues, err := r.resolveByType(serviceType, false)
 	if err != nil {
 		return reflect.Value{}, err
 	}
@@ -274,15 +277,25 @@ func (r *registry) resolveRegular(serviceType reflect.Type) (reflect.Value, erro
 	return resolvedValues[0], nil
 }
 
-// resolveByType resolves all service fits to specified type.
-func (r *registry) resolveByType(serviceType reflect.Type) ([]reflect.Value, error) {
+// resolveByType resolves the services that fit the specified type. When all is
+// false, only the first matching factory is spawned and returned, which is what
+// regular and optional resolution need; when all is true, every matching factory
+// is spawned, which is what Multiple resolution needs. This matters for interface
+// types with several implementations: a regular or optional dependency must not
+// instantiate the implementations it does not return.
+func (r *registry) resolveByType(serviceType reflect.Type, all bool) ([]reflect.Value, error) {
 	// Lookup factory definition by an output type.
 	factories := r.findFactories(serviceType)
+
+	// Avoid spawning the remaining implementations.
+	if !all && len(factories) > 1 {
+		factories = factories[:1]
+	}
 
 	// Prepare result values slice.
 	results := make([]reflect.Value, 0, len(factories))
 
-	// Spawn all found factories.
+	// Spawn the selected factories.
 	for _, fact := range factories {
 		// Handle found factory definition.
 		if err := r.spawnFactory(fact); err != nil {

--- a/registry.go
+++ b/registry.go
@@ -226,7 +226,7 @@ func (r *registry) resolveService(serviceType reflect.Type) (reflect.Value, erro
 
 // resolveOptional resolves a service wrapped with an optional type.
 func (r *registry) resolveOptional(optionalType, serviceType reflect.Type) (reflect.Value, error) {
-	// Resolve the first matching service by specified type.
+	// Resolve the first matching service by a specified type.
 	serviceValues, err := r.resolveByType(serviceType, false)
 	if err != nil {
 		return reflect.Value{}, err
@@ -263,7 +263,7 @@ func (r *registry) resolveMultiple(multipleType, serviceType reflect.Type) (refl
 // interface type with several registered implementations, the first one in
 // registration order is returned by design, and only that implementation is spawned.
 func (r *registry) resolveRegular(serviceType reflect.Type) (reflect.Value, error) {
-	// Resolve the first matching service by specified type.
+	// Resolve the first matching service by a specified type.
 	resolvedValues, err := r.resolveByType(serviceType, false)
 	if err != nil {
 		return reflect.Value{}, err

--- a/registry.go
+++ b/registry.go
@@ -249,7 +249,7 @@ func (r *registry) resolveOptional(optionalType, serviceType reflect.Type) (refl
 
 // resolveMultiple resolves all services fits to the multiple type.
 func (r *registry) resolveMultiple(multipleType, serviceType reflect.Type) (reflect.Value, error) {
-	// Resolve all services by specified type; Multiple spawns every match.
+	// Resolve all matching services by a specified type.
 	serviceValues, err := r.resolveByType(serviceType, true)
 	if err != nil {
 		return reflect.Value{}, err

--- a/registry.go
+++ b/registry.go
@@ -226,8 +226,7 @@ func (r *registry) resolveService(serviceType reflect.Type) (reflect.Value, erro
 
 // resolveOptional resolves a service wrapped with an optional type.
 func (r *registry) resolveOptional(optionalType, serviceType reflect.Type) (reflect.Value, error) {
-	// Resolve the service by specified type. Only the first matching factory is
-	// spawned; optional resolution never instantiates additional implementations.
+	// Resolve the first matching service by specified type.
 	serviceValues, err := r.resolveByType(serviceType, false)
 	if err != nil {
 		return reflect.Value{}, err
@@ -264,7 +263,7 @@ func (r *registry) resolveMultiple(multipleType, serviceType reflect.Type) (refl
 // interface type with several registered implementations, the first one in
 // registration order is returned by design, and only that implementation is spawned.
 func (r *registry) resolveRegular(serviceType reflect.Type) (reflect.Value, error) {
-	// Resolve the service by specified type.
+	// Resolve the first matching service by specified type.
 	resolvedValues, err := r.resolveByType(serviceType, false)
 	if err != nil {
 		return reflect.Value{}, err

--- a/registry_test.go
+++ b/registry_test.go
@@ -219,6 +219,64 @@ func TestRegistryValidateFactories(t *testing.T) {
 	}
 }
 
+// greeter and its implementations exercise regular interface resolution with more
+// than one candidate.
+type greeter interface{ greet() string }
+
+// englishGreeter is the first registered greeter implementation.
+type englishGreeter struct{}
+
+// greet returns the English greeting.
+func (englishGreeter) greet() string { return "hello" }
+
+// frenchGreeter is the second registered greeter implementation.
+type frenchGreeter struct{}
+
+// greet returns the French greeting.
+func (frenchGreeter) greet() string { return "bonjour" }
+
+// TestRegistryResolveInterfaceSingle verifies that resolving an interface as a regular
+// dependency returns the first registered implementation and does not spawn the others.
+func TestRegistryResolveInterfaceSingle(t *testing.T) {
+	var englishSpawned, frenchSpawned atomic.Int32
+	var got string
+
+	err := Run(
+		NewFactory(func() englishGreeter { englishSpawned.Add(1); return englishGreeter{} }),
+		NewFactory(func() frenchGreeter { frenchSpawned.Add(1); return frenchGreeter{} }),
+		NewEntrypoint(func(g greeter) { got = g.greet() }),
+	)
+
+	equal(t, err, nil)
+	equal(t, got, "hello")
+	equal(t, englishSpawned.Load(), int32(1))
+	equal(t, frenchSpawned.Load(), int32(0))
+}
+
+// TestRegistryResolveInterfaceMultiple verifies that resolving an interface through
+// Multiple returns every registered implementation and spawns all of them.
+func TestRegistryResolveInterfaceMultiple(t *testing.T) {
+	var englishSpawned, frenchSpawned atomic.Int32
+	var got []string
+
+	err := Run(
+		NewFactory(func() englishGreeter { englishSpawned.Add(1); return englishGreeter{} }),
+		NewFactory(func() frenchGreeter { frenchSpawned.Add(1); return frenchGreeter{} }),
+		NewEntrypoint(func(greeters Multiple[greeter]) {
+			for _, g := range greeters {
+				got = append(got, g.greet())
+			}
+		}),
+	)
+
+	equal(t, err, nil)
+	equal(t, len(got), 2)
+	equal(t, got[0], "hello")
+	equal(t, got[1], "bonjour")
+	equal(t, englishSpawned.Load(), int32(1))
+	equal(t, frenchSpawned.Load(), int32(1))
+}
+
 // TestRegistryInvokeFunctions tests corresponding registry method.
 func TestRegistryInvokeFunctions(t *testing.T) {
 	registry := &registry{}
@@ -255,7 +313,7 @@ func TestRegistryResolveParallel(t *testing.T) {
 	wg.Add(10)
 	for x := 0; x < 10; x++ {
 		go func() {
-			values, err := registry.resolveByType(reflect.TypeOf(true))
+			values, err := registry.resolveByType(reflect.TypeOf(true), false)
 			equal(t, err, nil)
 			equal(t, values[0].Interface(), true)
 			wg.Done()


### PR DESCRIPTION
Regular and optional resolution of an interface with several implementations now spawns and returns only the first match in registration order; Multiple[T] still spawns every match.

Add regression tests for both regular and Multiple resolution and document the first-match behavior.