### PR TITLE
Detect Optional/Multiple boxes via marker methods

### DIFF
--- a/multiple.go
+++ b/multiple.go
@@ -53,21 +53,12 @@ type multipleBox interface {
 
 // isMultipleType checks and returns multiple box type.
 func isMultipleType(typ reflect.Type) (reflect.Type, bool) {
-	// The kind guard both rejects embedders and prevents a nil-pointer panic.
-	// Embedding is the only way to inherit Multiple's promoted marker, and it is
-	// possible only in a struct, so anything that is not a slice cannot be a
-	// multiple box. The guard also stops a *Multiple[T] parameter: reflect.Zero
-	// of a pointer is a nil pointer whose method set still includes the
-	// value-receiver marker, which would panic when the marker dereferenced it.
+	// Check if the type is a slice.
 	if typ.Kind() != reflect.Slice {
 		return nil, false
 	}
 
-	// A slice that implements multipleBox can only be Multiple[T] itself:
-	// multipleBox has an unexported method, so it is satisfiable only inside this
-	// package, and no other slice type carries that marker. Unlike Optional - a
-	// struct whose embedders share its kind - Multiple needs no self-identity
-	// check, because the kind guard above already excludes every embedder.
+	// Check if the type is a Multiple type.
 	box, ok := reflect.Zero(typ).Interface().(multipleBox)
 	if !ok {
 		return nil, false

--- a/multiple.go
+++ b/multiple.go
@@ -37,26 +37,46 @@ import "reflect"
 //	}
 type Multiple[T any] []T
 
+// multipleSelf reports Multiple's own instantiated type. It lets isMultipleType
+// reject user types that merely embed Multiple[T] and promote its markers: for
+// an embedder the promoted receiver is the embedded box, so multipleSelf still
+// returns the Multiple type, not the outer type.
+func (m Multiple[T]) multipleSelf() reflect.Type {
+	return reflect.TypeOf(m)
+}
+
 // multipleElem reports the element type T. Inside the instantiated method T is
 // known statically, so it is read directly from the type parameter rather than
 // reverse-engineered from the slice's element type.
-func (Multiple[T]) multipleElem() reflect.Type {
+func (m Multiple[T]) multipleElem() reflect.Type {
 	return reflect.TypeOf((*T)(nil)).Elem()
 }
 
 // multipleBox is the internal contract implemented only by Multiple[T]. The
-// value receiver lets isMultipleType detect the box from a plain reflect.Zero
+// value receivers let isMultipleType detect the box from a plain reflect.Zero
 // value without any pointer indirection.
 type multipleBox interface {
+	multipleSelf() reflect.Type
 	multipleElem() reflect.Type
 }
 
 // isMultipleType checks and returns multiple box type.
 func isMultipleType(typ reflect.Type) (reflect.Type, bool) {
-	box, ok := reflect.Zero(typ).Interface().(multipleBox)
-	if !ok {
+	// The kind guard is essential: reflect.Zero of a pointer type is a nil
+	// pointer whose method set still includes the value-receiver markers, so
+	// without it a *Multiple[T] parameter would satisfy multipleBox and then
+	// panic when a marker method dereferenced the nil pointer.
+	if typ.Kind() != reflect.Slice {
 		return nil, false
 	}
+
+	// The multipleSelf identity check rejects user slices that embed Multiple[T]
+	// and inherit its promoted markers.
+	box, ok := reflect.Zero(typ).Interface().(multipleBox)
+	if !ok || box.multipleSelf() != typ {
+		return nil, false
+	}
+
 	return box.multipleElem(), true
 }
 

--- a/multiple.go
+++ b/multiple.go
@@ -37,14 +37,6 @@ import "reflect"
 //	}
 type Multiple[T any] []T
 
-// multipleSelf reports Multiple's own instantiated type. It lets isMultipleType
-// reject user types that merely embed Multiple[T] and promote its markers: for
-// an embedder the promoted receiver is the embedded box, so multipleSelf still
-// returns the Multiple type, not the outer type.
-func (m Multiple[T]) multipleSelf() reflect.Type {
-	return reflect.TypeOf(m)
-}
-
 // multipleElem reports the element type T. Inside the instantiated method T is
 // known statically, so it is read directly from the type parameter rather than
 // reverse-engineered from the slice's element type.
@@ -53,27 +45,31 @@ func (m Multiple[T]) multipleElem() reflect.Type {
 }
 
 // multipleBox is the internal contract implemented only by Multiple[T]. The
-// value receivers let isMultipleType detect the box from a plain reflect.Zero
+// value receiver lets isMultipleType detect the box from a plain reflect.Zero
 // value without any pointer indirection.
 type multipleBox interface {
-	multipleSelf() reflect.Type
 	multipleElem() reflect.Type
 }
 
 // isMultipleType checks and returns multiple box type.
 func isMultipleType(typ reflect.Type) (reflect.Type, bool) {
-	// The kind guard is essential: reflect.Zero of a pointer type is a nil
-	// pointer whose method set still includes the value-receiver markers, so
-	// without it a *Multiple[T] parameter would satisfy multipleBox and then
-	// panic when a marker method dereferenced the nil pointer.
+	// The kind guard both rejects embedders and prevents a nil-pointer panic.
+	// Embedding is the only way to inherit Multiple's promoted marker, and it is
+	// possible only in a struct, so anything that is not a slice cannot be a
+	// multiple box. The guard also stops a *Multiple[T] parameter: reflect.Zero
+	// of a pointer is a nil pointer whose method set still includes the
+	// value-receiver marker, which would panic when the marker dereferenced it.
 	if typ.Kind() != reflect.Slice {
 		return nil, false
 	}
 
-	// The multipleSelf identity check rejects user slices that embed Multiple[T]
-	// and inherit its promoted markers.
+	// A slice that implements multipleBox can only be Multiple[T] itself:
+	// multipleBox has an unexported method, so it is satisfiable only inside this
+	// package, and no other slice type carries that marker. Unlike Optional - a
+	// struct whose embedders share its kind - Multiple needs no self-identity
+	// check, because the kind guard above already excludes every embedder.
 	box, ok := reflect.Zero(typ).Interface().(multipleBox)
-	if !ok || box.multipleSelf() != typ {
+	if !ok {
 		return nil, false
 	}
 

--- a/multiple.go
+++ b/multiple.go
@@ -37,16 +37,12 @@ import "reflect"
 //	}
 type Multiple[T any] []T
 
-// multipleElem reports the element type T. Inside the instantiated method T is
-// known statically, so it is read directly from the type parameter rather than
-// reverse-engineered from the slice's element type.
+// multipleElem reports the wrapped element type T.
 func (m Multiple[T]) multipleElem() reflect.Type {
 	return reflect.TypeOf((*T)(nil)).Elem()
 }
 
-// multipleBox is the internal contract implemented only by Multiple[T]. The
-// value receiver lets isMultipleType detect the box from a plain reflect.Zero
-// value without any pointer indirection.
+// multipleBox is the internal contract implemented only by Multiple[T].
 type multipleBox interface {
 	multipleElem() reflect.Type
 }

--- a/multiple.go
+++ b/multiple.go
@@ -17,10 +17,7 @@
 
 package gontainer
 
-import (
-	"reflect"
-	"strings"
-)
+import "reflect"
 
 // Multiple defines a dependency on zero or more services of the same type.
 //
@@ -40,32 +37,30 @@ import (
 //	}
 type Multiple[T any] []T
 
+// multipleElem reports the element type T. Inside the instantiated method T is
+// known statically, so it is read directly from the type parameter rather than
+// reverse-engineered from the slice's element type.
+func (Multiple[T]) multipleElem() reflect.Type {
+	return reflect.TypeOf((*T)(nil)).Elem()
+}
+
+// multipleBox is the internal contract implemented only by Multiple[T]. The
+// value receiver lets isMultipleType detect the box from a plain reflect.Zero
+// value without any pointer indirection.
+type multipleBox interface {
+	multipleElem() reflect.Type
+}
+
 // isMultipleType checks and returns multiple box type.
 func isMultipleType(typ reflect.Type) (reflect.Type, bool) {
-	// Check if the type is a slice.
-	if typ.Kind() != reflect.Slice {
+	box, ok := reflect.Zero(typ).Interface().(multipleBox)
+	if !ok {
 		return nil, false
 	}
-
-	// Check if the type is a Multiple type.
-	sample := reflect.TypeOf(Multiple[struct{}]{})
-	if typ.PkgPath() != sample.PkgPath() {
-		return nil, false
-	}
-
-	// Check if the type is a Multiple type.
-	sampleName := sample.Name()
-	sep := strings.IndexByte(sampleName, '[')
-	if sep < 0 || !strings.HasPrefix(typ.Name(), sampleName[:sep+1]) {
-		return nil, false
-	}
-
-	// Return the element type of the slice.
-	return typ.Elem(), true
+	return box.multipleElem(), true
 }
 
 // newMultipleValue packs multiple values to the slice.
 func newMultipleValue(typ reflect.Type, values []reflect.Value) reflect.Value {
-	box := reflect.New(typ).Elem()
-	return reflect.Append(box, values...)
+	return reflect.Append(reflect.Zero(typ), values...)
 }

--- a/multiple_test.go
+++ b/multiple_test.go
@@ -68,6 +68,11 @@ func TestIsMultipleTypeEmbedded(t *testing.T) {
 	}
 
 	typ := reflect.TypeOf(embedsMultiple{})
+
+	// The embedder satisfies multipleBox through promotion.
+	_, satisfies := reflect.Zero(typ).Interface().(multipleBox)
+	equal(t, satisfies, true)
+
 	rtyp, ok := isMultipleType(typ)
 	equal(t, ok, false)
 	equal(t, rtyp, nil)

--- a/multiple_test.go
+++ b/multiple_test.go
@@ -44,15 +44,9 @@ func TestIsMultipleType(t *testing.T) {
 	equal(t, ok, true)
 }
 
-// TestIsMultipleTypePointer verifies that a *Multiple[T] parameter type is
-// rejected cleanly rather than panicking. reflect.Zero of a pointer is a nil
-// pointer whose method set still includes Multiple's value receiver, so a bare
-// marker-interface assertion would call multipleElem() on nil and dereference it.
+// TestIsMultipleTypePointer tests that a *Multiple[T] type is rejected without a panic.
 func TestIsMultipleTypePointer(t *testing.T) {
-	// DEFENSIVE (not a real use case): *Multiple[T] is not a legitimate parameter
-	// type - Multiple[T] is taken by value. This only pins that such input degrades
-	// to a clean dependency error instead of panicking, as it did pre-refactor.
-	typ := reflect.TypeOf((*Multiple[int])(nil)) // *Multiple[int]
+	typ := reflect.TypeOf((*Multiple[int])(nil))
 
 	defer func() {
 		if r := recover(); r != nil {

--- a/multiple_test.go
+++ b/multiple_test.go
@@ -56,6 +56,9 @@ type embedsMultiple struct {
 // pointer whose method set still includes Multiple's value receiver, so a bare
 // marker-interface assertion would call multipleElem() on nil and dereference it.
 func TestIsMultipleTypePointer(t *testing.T) {
+	// DEFENSIVE (not a real use case): *Multiple[T] is not a legitimate parameter
+	// type - Multiple[T] is taken by value. This only pins that such input degrades
+	// to a clean dependency error instead of panicking, as it did pre-refactor.
 	typ := reflect.TypeOf((*Multiple[int])(nil)) // *Multiple[int]
 
 	defer func() {

--- a/multiple_test.go
+++ b/multiple_test.go
@@ -44,6 +44,41 @@ func TestIsMultipleType(t *testing.T) {
 	equal(t, ok, true)
 }
 
+// embedsMultiple is a user-defined struct that embeds Multiple[T]. It is NOT a
+// multiple box: it merely promotes Multiple's marker method. The container must
+// treat it as a regular dependency, not misdetect it as a box.
+type embedsMultiple struct {
+	Multiple[int]
+}
+
+// TestIsMultipleTypePointer verifies that a *Multiple[T] parameter type is
+// rejected cleanly rather than panicking. reflect.Zero of a pointer is a nil
+// pointer whose method set still includes Multiple's value receiver, so a bare
+// marker-interface assertion would call multipleElem() on nil and dereference it.
+func TestIsMultipleTypePointer(t *testing.T) {
+	typ := reflect.TypeOf((*Multiple[int])(nil)) // *Multiple[int]
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("isMultipleType panicked on *Multiple[int]: %v", r)
+		}
+	}()
+
+	rtyp, ok := isMultipleType(typ)
+	equal(t, rtyp, nil)
+	equal(t, ok, false)
+}
+
+// TestIsMultipleTypeEmbedded verifies that a user struct embedding Multiple[T]
+// is not misdetected as a multiple box via the promoted marker method.
+func TestIsMultipleTypeEmbedded(t *testing.T) {
+	typ := reflect.TypeOf(embedsMultiple{})
+
+	rtyp, ok := isMultipleType(typ)
+	equal(t, ok, false)
+	equal(t, rtyp, nil)
+}
+
 // TestNewMultipleValue tests creation of multiple value.
 func TestNewMultipleValue(t *testing.T) {
 	// When multiple not found.

--- a/multiple_test.go
+++ b/multiple_test.go
@@ -44,13 +44,6 @@ func TestIsMultipleType(t *testing.T) {
 	equal(t, ok, true)
 }
 
-// embedsMultiple is a user-defined struct that embeds Multiple[T]. It is NOT a
-// multiple box: it merely promotes Multiple's marker method. The container must
-// treat it as a regular dependency, not misdetect it as a box.
-type embedsMultiple struct {
-	Multiple[int]
-}
-
 // TestIsMultipleTypePointer verifies that a *Multiple[T] parameter type is
 // rejected cleanly rather than panicking. reflect.Zero of a pointer is a nil
 // pointer whose method set still includes Multiple's value receiver, so a bare
@@ -75,6 +68,16 @@ func TestIsMultipleTypePointer(t *testing.T) {
 // TestIsMultipleTypeEmbedded verifies that a user struct embedding Multiple[T]
 // is not misdetected as a multiple box via the promoted marker method.
 func TestIsMultipleTypeEmbedded(t *testing.T) {
+	// embedsMultiple is a user-defined struct that embeds Multiple[T]. It is NOT a
+	// multiple box: it merely promotes Multiple's marker method. The container must
+	// treat it as a regular dependency, not misdetect it as a box.
+	type embedsMultiple struct {
+		Multiple[int]
+	}
+
+	// DEFENSIVE (not a real use case): embedding Multiple[T] in a struct is not how
+	// the API is used. This only pins that such input is not misdetected as a box,
+	// matching pre-refactor behaviour.
 	typ := reflect.TypeOf(embedsMultiple{})
 
 	rtyp, ok := isMultipleType(typ)

--- a/multiple_test.go
+++ b/multiple_test.go
@@ -66,20 +66,14 @@ func TestIsMultipleTypePointer(t *testing.T) {
 }
 
 // TestIsMultipleTypeEmbedded verifies that a user struct embedding Multiple[T]
-// is not misdetected as a multiple box via the promoted marker method.
+// is not misdetected as a multiple box.
 func TestIsMultipleTypeEmbedded(t *testing.T) {
-	// embedsMultiple is a user-defined struct that embeds Multiple[T]. It is NOT a
-	// multiple box: it merely promotes Multiple's marker method. The container must
-	// treat it as a regular dependency, not misdetect it as a box.
+	// embedsMultiple inherits all embedded type methods.
 	type embedsMultiple struct {
 		Multiple[int]
 	}
 
-	// DEFENSIVE (not a real use case): embedding Multiple[T] in a struct is not how
-	// the API is used. This only pins that such input is not misdetected as a box,
-	// matching pre-refactor behaviour.
 	typ := reflect.TypeOf(embedsMultiple{})
-
 	rtyp, ok := isMultipleType(typ)
 	equal(t, ok, false)
 	equal(t, rtyp, nil)

--- a/optional.go
+++ b/optional.go
@@ -49,6 +49,14 @@ func (o Optional[T]) Ok() bool {
 	return o.ok
 }
 
+// optionalSelf reports Optional's own instantiated type. It lets isOptionalType
+// reject user types that merely embed Optional[T] and promote its markers: for
+// an embedder the promoted receiver is the embedded box, so optionalSelf still
+// returns the Optional type, not the outer type.
+func (o Optional[T]) optionalSelf() reflect.Type {
+	return reflect.TypeOf(o)
+}
+
 // optionalElem reports the wrapped type T. Inside the instantiated method T is
 // known statically, so it is read directly from the type parameter rather than
 // reverse-engineered from a struct field.
@@ -57,27 +65,43 @@ func (o Optional[T]) optionalElem() reflect.Type {
 }
 
 // withValue returns a present optional box carrying v. T is known inside the
-// instantiated method, so v is unwrapped with a plain type assertion - no
-// reflection-based mutation of an unexported field is needed.
+// instantiated method, so v is unwrapped with a comma-ok assertion rather than
+// reflection-based mutation of an unexported field. The comma-ok form is
+// deliberate: a service that resolved to a nil interface value yields the zero
+// (nil) T with ok still true - matching the old reflect.Set behaviour - instead
+// of panicking on a nil interface conversion.
 func (o Optional[T]) withValue(v reflect.Value) any {
-	return Optional[T]{value: v.Interface().(T), ok: true}
+	value, _ := v.Interface().(T)
+	return Optional[T]{value: value, ok: true}
 }
 
-// optionalBox is the internal contract implemented only by Optional[T]. Both
+// optionalBox is the internal contract implemented only by Optional[T]. All
 // methods use value receivers, so an instantiated Optional[T] satisfies it
 // without any pointer indirection - this is what lets isOptionalType detect the
 // box from a plain reflect.Zero value and build one without addressability.
 type optionalBox interface {
+	optionalSelf() reflect.Type
 	optionalElem() reflect.Type
 	withValue(v reflect.Value) any
 }
 
 // isOptionalType checks and returns optional box type.
 func isOptionalType(typ reflect.Type) (reflect.Type, bool) {
-	box, ok := reflect.Zero(typ).Interface().(optionalBox)
-	if !ok {
+	// The kind guard is essential: reflect.Zero of a pointer type is a nil
+	// pointer whose method set still includes the value-receiver markers, so
+	// without it a *Optional[T] parameter would satisfy optionalBox and then
+	// panic when a marker method dereferenced the nil pointer.
+	if typ.Kind() != reflect.Struct {
 		return nil, false
 	}
+
+	// The optionalSelf identity check rejects user structs that embed Optional[T]
+	// and inherit its promoted markers.
+	box, ok := reflect.Zero(typ).Interface().(optionalBox)
+	if !ok || box.optionalSelf() != typ {
+		return nil, false
+	}
+
 	return box.optionalElem(), true
 }
 

--- a/optional.go
+++ b/optional.go
@@ -17,10 +17,7 @@
 
 package gontainer
 
-import (
-	"reflect"
-	"strings"
-)
+import "reflect"
 
 // Optional defines a dependency on a service that may or may not be registered.
 //
@@ -43,60 +40,51 @@ type Optional[T any] struct {
 }
 
 // Get returns the optional service instance.
-func (o *Optional[T]) Get() T {
+func (o Optional[T]) Get() T {
 	return o.value
 }
 
 // Ok reports whether the optional service was provided by the container.
-func (o *Optional[T]) Ok() bool {
+func (o Optional[T]) Ok() bool {
 	return o.ok
 }
 
-// setValue populates the private value field.
-func (o *Optional[T]) setValue(v reflect.Value) {
-	reflect.ValueOf(&o.value).Elem().Set(v)
-	o.ok = true
+// optionalElem reports the wrapped type T. Inside the instantiated method T is
+// known statically, so it is read directly from the type parameter rather than
+// reverse-engineered from a struct field.
+func (o Optional[T]) optionalElem() reflect.Type {
+	return reflect.TypeOf((*T)(nil)).Elem()
+}
+
+// withValue returns a present optional box carrying v. T is known inside the
+// instantiated method, so v is unwrapped with a plain type assertion - no
+// reflection-based mutation of an unexported field is needed.
+func (o Optional[T]) withValue(v reflect.Value) any {
+	return Optional[T]{value: v.Interface().(T), ok: true}
+}
+
+// optionalBox is the internal contract implemented only by Optional[T]. Both
+// methods use value receivers, so an instantiated Optional[T] satisfies it
+// without any pointer indirection - this is what lets isOptionalType detect the
+// box from a plain reflect.Zero value and build one without addressability.
+type optionalBox interface {
+	optionalElem() reflect.Type
+	withValue(v reflect.Value) any
 }
 
 // isOptionalType checks and returns optional box type.
 func isOptionalType(typ reflect.Type) (reflect.Type, bool) {
-	// Check if the type is a struct.
-	if typ.Kind() != reflect.Struct {
-		return nil, false
-	}
-
-	// Check if the type is a Optional type.
-	sample := reflect.TypeOf(Optional[struct{}]{})
-	if typ.PkgPath() != sample.PkgPath() {
-		return nil, false
-	}
-
-	// Check if the type is a Optional type.
-	sampleName := sample.Name()
-	sep := strings.IndexByte(sampleName, '[')
-	if sep < 0 || !strings.HasPrefix(typ.Name(), sampleName[:sep+1]) {
-		return nil, false
-	}
-
-	// Check if the type has a value field.
-	field, ok := typ.FieldByName("value")
+	box, ok := reflect.Zero(typ).Interface().(optionalBox)
 	if !ok {
 		return nil, false
 	}
-
-	// Return the type of the value field.
-	return field.Type, true
+	return box.optionalElem(), true
 }
 
 // newOptionalValue creates new optional type with a value.
 func newOptionalValue(typ reflect.Type, value reflect.Value) reflect.Value {
-	// Allocate an addressable pointer to a zero Optional[T].
-	ptr := reflect.New(typ)
-
-	// Populate the private field via the internal setter interface.
-	ptr.Interface().(interface{ setValue(reflect.Value) }).setValue(value)
-
-	return ptr.Elem()
+	box := reflect.Zero(typ).Interface().(optionalBox)
+	return reflect.ValueOf(box.withValue(value))
 }
 
 // newOptionalZero creates a new optional type with no value and ok set to false.

--- a/optional.go
+++ b/optional.go
@@ -49,36 +49,25 @@ func (o Optional[T]) Ok() bool {
 	return o.ok
 }
 
-// optionalSelf reports Optional's own instantiated type. It lets isOptionalType
-// reject user types that merely embed Optional[T] and promote its markers: for
-// an embedder the promoted receiver is the embedded box, so optionalSelf still
-// returns the Optional type, not the outer type.
+// optionalSelf reports Optional's own instantiated type, used to reject types
+// that merely embed Optional[T] and promote its methods.
 func (o Optional[T]) optionalSelf() reflect.Type {
 	return reflect.TypeOf(o)
 }
 
-// optionalElem reports the wrapped type T. Inside the instantiated method T is
-// known statically, so it is read directly from the type parameter rather than
-// reverse-engineered from a struct field.
+// optionalElem reports the wrapped type T.
 func (o Optional[T]) optionalElem() reflect.Type {
 	return reflect.TypeOf((*T)(nil)).Elem()
 }
 
-// withValue returns a present optional box carrying v. T is known inside the
-// instantiated method, so v is unwrapped with a comma-ok assertion rather than
-// reflection-based mutation of an unexported field. The comma-ok form is
-// deliberate: a service that resolved to a nil interface value yields the zero
-// (nil) T with ok still true - matching the old reflect.Set behaviour - instead
-// of panicking on a nil interface conversion.
+// withValue returns a present optional box carrying v. The comma-ok assertion
+// keeps a nil interface value as the zero T with ok set, instead of panicking.
 func (o Optional[T]) withValue(v reflect.Value) any {
 	value, _ := v.Interface().(T)
 	return Optional[T]{value: value, ok: true}
 }
 
-// optionalBox is the internal contract implemented only by Optional[T]. All
-// methods use value receivers, so an instantiated Optional[T] satisfies it
-// without any pointer indirection - this is what lets isOptionalType detect the
-// box from a plain reflect.Zero value and build one without addressability.
+// optionalBox is the internal contract implemented only by Optional[T].
 type optionalBox interface {
 	optionalSelf() reflect.Type
 	optionalElem() reflect.Type
@@ -87,16 +76,12 @@ type optionalBox interface {
 
 // isOptionalType checks and returns optional box type.
 func isOptionalType(typ reflect.Type) (reflect.Type, bool) {
-	// The kind guard is essential: reflect.Zero of a pointer type is a nil
-	// pointer whose method set still includes the value-receiver markers, so
-	// without it a *Optional[T] parameter would satisfy optionalBox and then
-	// panic when a marker method dereferenced the nil pointer.
+	// Check if the type is a struct.
 	if typ.Kind() != reflect.Struct {
 		return nil, false
 	}
 
-	// The optionalSelf identity check rejects user structs that embed Optional[T]
-	// and inherit its promoted markers.
+	// Check if the type is an Optional type, rejecting structs that only embed it.
 	box, ok := reflect.Zero(typ).Interface().(optionalBox)
 	if !ok || box.optionalSelf() != typ {
 		return nil, false

--- a/optional_test.go
+++ b/optional_test.go
@@ -44,18 +44,6 @@ func TestIsOptionalType(t *testing.T) {
 	equal(t, ok, true)
 }
 
-// embedsOptional is a user-defined struct that embeds Optional[T]. It is NOT an
-// optional box: it merely promotes Optional's marker methods. The container must
-// treat it as a regular dependency, not misdetect it as a box.
-type embedsOptional struct {
-	Optional[int]
-	Extra int
-}
-
-// optNilIface is an interface used to exercise a service that resolves to a
-// legitimately nil interface value.
-type optNilIface interface{ marker() }
-
 // TestIsOptionalTypePointer verifies that a *Optional[T] parameter type is
 // rejected cleanly (regular dependency) rather than panicking. reflect.Zero of a
 // pointer is a nil pointer whose method set still includes Optional's value
@@ -83,6 +71,17 @@ func TestIsOptionalTypePointer(t *testing.T) {
 // methods, so a bare interface assertion would match it and later build the
 // wrong (inner) type.
 func TestIsOptionalTypeEmbedded(t *testing.T) {
+	// embedsOptional is a user-defined struct that embeds Optional[T]. It is NOT an
+	// optional box: it merely promotes Optional's marker methods. The container must
+	// treat it as a regular dependency, not misdetect it as a box.
+	type embedsOptional struct {
+		Optional[int]
+		Extra int
+	}
+
+	// DEFENSIVE (not a real use case): embedding Optional[T] in a struct is not how
+	// the API is used. This only pins that such input is not misdetected as a box
+	// (which would later build the wrong type), matching pre-refactor behaviour.
 	typ := reflect.TypeOf(embedsOptional{})
 
 	rtyp, ok := isOptionalType(typ)
@@ -95,6 +94,10 @@ func TestIsOptionalTypeEmbedded(t *testing.T) {
 // than panicking. The old setValue path used reflect.Set, which accepts nil; a
 // v.Interface().(T) assertion panics because the interface is nil.
 func TestNewOptionalValueNilInterface(t *testing.T) {
+	// optNilIface is an interface used to exercise a service that resolves to a
+	// legitimately nil interface value.
+	type optNilIface interface{ marker() }
+
 	var svc optNilIface                  // nil interface
 	data := reflect.ValueOf(&svc).Elem() // reflect.Value of interface type, nil
 

--- a/optional_test.go
+++ b/optional_test.go
@@ -74,6 +74,24 @@ func TestOptionalOkNotProvided(t *testing.T) {
 	}
 }
 
+// TestOptionalValueSemantics verifies that Get and Ok are callable on
+// non-addressable values (e.g. a map element), i.e. that they use value
+// receivers. With pointer receivers this would not compile.
+func TestOptionalValueSemantics(t *testing.T) {
+	boxes := map[string]Optional[string]{
+		"present": newOptionalValue(
+			reflect.TypeOf(Optional[string]{}),
+			reflect.ValueOf("hi"),
+		).Interface().(Optional[string]),
+		"absent": {},
+	}
+
+	equal(t, boxes["present"].Ok(), true)
+	equal(t, boxes["present"].Get(), "hi")
+	equal(t, boxes["absent"].Ok(), false)
+	equal(t, boxes["absent"].Get(), "")
+}
+
 // TestOptionalOkProvided tests that Ok returns true when the service is provided.
 func TestOptionalOkProvided(t *testing.T) {
 	typ := reflect.TypeOf(Optional[string]{})

--- a/optional_test.go
+++ b/optional_test.go
@@ -44,16 +44,9 @@ func TestIsOptionalType(t *testing.T) {
 	equal(t, ok, true)
 }
 
-// TestIsOptionalTypePointer verifies that a *Optional[T] parameter type is
-// rejected cleanly (regular dependency) rather than panicking. reflect.Zero of a
-// pointer is a nil pointer whose method set still includes Optional's value
-// receivers, so a bare marker-interface assertion would call optionalElem() on
-// nil and dereference it.
+// TestIsOptionalTypePointer tests that a *Optional[T] type is rejected without a panic.
 func TestIsOptionalTypePointer(t *testing.T) {
-	// DEFENSIVE (not a real use case): *Optional[T] is not a legitimate parameter
-	// type - Optional[T] is taken by value. This only pins that such input degrades
-	// to a clean dependency error instead of panicking, as it did pre-refactor.
-	typ := reflect.TypeOf((*Optional[int])(nil)) // *Optional[int]
+	typ := reflect.TypeOf((*Optional[int])(nil))
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -66,22 +59,15 @@ func TestIsOptionalTypePointer(t *testing.T) {
 	equal(t, ok, false)
 }
 
-// TestIsOptionalTypeEmbedded verifies that a user struct embedding Optional[T]
-// is not misdetected as an optional box. The embedded field promotes the marker
-// methods, so a bare interface assertion would match it and later build the
-// wrong (inner) type.
+// TestIsOptionalTypeEmbedded tests that a user struct embedding Optional[T] is
+// not misdetected as an optional box.
 func TestIsOptionalTypeEmbedded(t *testing.T) {
-	// embedsOptional is a user-defined struct that embeds Optional[T]. It is NOT an
-	// optional box: it merely promotes Optional's marker methods. The container must
-	// treat it as a regular dependency, not misdetect it as a box.
+	// embedsOptional inherits all embedded type methods.
 	type embedsOptional struct {
 		Optional[int]
 		Extra int
 	}
 
-	// DEFENSIVE (not a real use case): embedding Optional[T] in a struct is not how
-	// the API is used. This only pins that such input is not misdetected as a box
-	// (which would later build the wrong type), matching pre-refactor behaviour.
 	typ := reflect.TypeOf(embedsOptional{})
 
 	rtyp, ok := isOptionalType(typ)
@@ -89,17 +75,14 @@ func TestIsOptionalTypeEmbedded(t *testing.T) {
 	equal(t, rtyp, nil)
 }
 
-// TestNewOptionalValueNilInterface verifies that a service that resolves to a
-// nil interface value is boxed as a present optional (value nil, ok true) rather
-// than panicking. The old setValue path used reflect.Set, which accepts nil; a
-// v.Interface().(T) assertion panics because the interface is nil.
+// TestNewOptionalValueNilInterface tests that a service resolving to a nil
+// interface value is boxed as a present optional (nil value, ok true).
 func TestNewOptionalValueNilInterface(t *testing.T) {
-	// optNilIface is an interface used to exercise a service that resolves to a
-	// legitimately nil interface value.
+	// optNilIface exercises a service that resolves to a nil interface value.
 	type optNilIface interface{ marker() }
 
-	var svc optNilIface                  // nil interface
-	data := reflect.ValueOf(&svc).Elem() // reflect.Value of interface type, nil
+	var svc optNilIface
+	data := reflect.ValueOf(&svc).Elem()
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -143,9 +126,8 @@ func TestOptionalOkNotProvided(t *testing.T) {
 	}
 }
 
-// TestOptionalValueSemantics verifies that Get and Ok are callable on
-// non-addressable values (e.g. a map element), i.e. that they use value
-// receivers. With pointer receivers this would not compile.
+// TestOptionalValueSemantics tests that Get and Ok are callable on
+// non-addressable values, i.e. that they use value receivers.
 func TestOptionalValueSemantics(t *testing.T) {
 	boxes := map[string]Optional[string]{
 		"present": newOptionalValue(

--- a/optional_test.go
+++ b/optional_test.go
@@ -44,6 +44,69 @@ func TestIsOptionalType(t *testing.T) {
 	equal(t, ok, true)
 }
 
+// embedsOptional is a user-defined struct that embeds Optional[T]. It is NOT an
+// optional box: it merely promotes Optional's marker methods. The container must
+// treat it as a regular dependency, not misdetect it as a box.
+type embedsOptional struct {
+	Optional[int]
+	Extra int
+}
+
+// optNilIface is an interface used to exercise a service that resolves to a
+// legitimately nil interface value.
+type optNilIface interface{ marker() }
+
+// TestIsOptionalTypePointer verifies that a *Optional[T] parameter type is
+// rejected cleanly (regular dependency) rather than panicking. reflect.Zero of a
+// pointer is a nil pointer whose method set still includes Optional's value
+// receivers, so a bare marker-interface assertion would call optionalElem() on
+// nil and dereference it.
+func TestIsOptionalTypePointer(t *testing.T) {
+	typ := reflect.TypeOf((*Optional[int])(nil)) // *Optional[int]
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("isOptionalType panicked on *Optional[int]: %v", r)
+		}
+	}()
+
+	rtyp, ok := isOptionalType(typ)
+	equal(t, rtyp, nil)
+	equal(t, ok, false)
+}
+
+// TestIsOptionalTypeEmbedded verifies that a user struct embedding Optional[T]
+// is not misdetected as an optional box. The embedded field promotes the marker
+// methods, so a bare interface assertion would match it and later build the
+// wrong (inner) type.
+func TestIsOptionalTypeEmbedded(t *testing.T) {
+	typ := reflect.TypeOf(embedsOptional{})
+
+	rtyp, ok := isOptionalType(typ)
+	equal(t, ok, false)
+	equal(t, rtyp, nil)
+}
+
+// TestNewOptionalValueNilInterface verifies that a service that resolves to a
+// nil interface value is boxed as a present optional (value nil, ok true) rather
+// than panicking. The old setValue path used reflect.Set, which accepts nil; a
+// v.Interface().(T) assertion panics because the interface is nil.
+func TestNewOptionalValueNilInterface(t *testing.T) {
+	var svc optNilIface                  // nil interface
+	data := reflect.ValueOf(&svc).Elem() // reflect.Value of interface type, nil
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("newOptionalValue panicked on nil interface service: %v", r)
+		}
+	}()
+
+	value := newOptionalValue(reflect.TypeOf(Optional[optNilIface]{}), data)
+	opt := value.Interface().(Optional[optNilIface])
+	equal(t, opt.Ok(), true)
+	equal(t, opt.Get(), nil)
+}
+
 // TestNewOptionalValue tests creation of optional value.
 func TestNewOptionalValue(t *testing.T) {
 	// When optional not found.

--- a/optional_test.go
+++ b/optional_test.go
@@ -62,6 +62,9 @@ type optNilIface interface{ marker() }
 // receivers, so a bare marker-interface assertion would call optionalElem() on
 // nil and dereference it.
 func TestIsOptionalTypePointer(t *testing.T) {
+	// DEFENSIVE (not a real use case): *Optional[T] is not a legitimate parameter
+	// type - Optional[T] is taken by value. This only pins that such input degrades
+	// to a clean dependency error instead of panicking, as it did pre-refactor.
 	typ := reflect.TypeOf((*Optional[int])(nil)) // *Optional[int]
 
 	defer func() {

--- a/optional_test.go
+++ b/optional_test.go
@@ -70,6 +70,10 @@ func TestIsOptionalTypeEmbedded(t *testing.T) {
 
 	typ := reflect.TypeOf(embedsOptional{})
 
+	// The embedder satisfies optionalBox through promotion.
+	_, satisfies := reflect.Zero(typ).Interface().(optionalBox)
+	equal(t, satisfies, true)
+
 	rtyp, ok := isOptionalType(typ)
 	equal(t, ok, false)
 	equal(t, rtyp, nil)


### PR DESCRIPTION
Refine the internal detection of Optional[T] / Multiple[T] params. Instead of matching on the mangled generic type name (package path + "Optional[" string prefix), each type now carries a small unexported marker method that returns its element type from the type parameter directly, detection becomes a plain interface assertion, no longer tied to how the compiler names generics.

Also drops the reflection-based setValue on Optional in favor of a value-returning constructor, so Get/Ok become value receivers and work on non-addressable values (e.g. map entries). Added a test for that.