### PR TITLE
Validate user provided functions in the public API border.

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,21 @@ Expected failures should be returned as an `error` - which the container renders
 the structured traceback shown above - while a panic signals a programming error that
 you want to surface immediately rather than silently absorb.
 
+In addition, public interface validates its arguments at the boundary and panics on misuse,
+with a message prefixed by `gontainer:`. These panics indicate a programming error
+in the caller, not a runtime failure:
+
+- `NewFactory` and `NewEntrypoint` panic when the argument is `nil`, is not a
+  function, is a typed nil function, or has an unsupported signature.
+- `Invoker.Invoke` panics when the argument is `nil`, is not a function, or is a
+  typed nil function.
+- `Resolver.Resolve` panics when the target is not a valid, non-nil, writable
+  pointer.
+
+Valid calls never panic for these reasons: any failure during dependency
+resolution, graph construction, factory or entrypoint execution, invocation, or
+cleanup is still returned as an `error`.
+
 ## Contributing
 
 We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/README.md
+++ b/README.md
@@ -526,9 +526,8 @@ Expected failures should be returned as an `error` - which the container renders
 the structured traceback shown above - while a panic signals a programming error that
 you want to surface immediately rather than silently absorb.
 
-In addition, public interface validates its arguments at the boundary and panics on misuse,
-with a message prefixed by `gontainer:`. These panics indicate a programming error
-in the caller, not a runtime failure:
+In addition, the public interface validates its arguments at the boundary and panics on
+misuse. These panics indicate a programming error in the caller, not a runtime failure:
 
 - `NewFactory` and `NewEntrypoint` panic when the argument is `nil`, is not a
   function, is a typed nil function, or has an unsupported signature.

--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ Expected failures should be returned as an `error` - which the container renders
 the structured traceback shown above - while a panic signals a programming error that
 you want to surface immediately rather than silently absorb.
 
-In addition, the public interface validates its arguments at the boundary and panics on
+In addition, the public interface validates its arguments eagerly and panics on
 misuse. These panics indicate a programming error in the caller, not a runtime failure:
 
 - `NewFactory` and `NewEntrypoint` panic when the argument is `nil`, is not a

--- a/container.go
+++ b/container.go
@@ -93,23 +93,49 @@ type Option interface {
 	apply(registry *registry) error
 }
 
-// NewFactory creates a new service load using the provided load function.
+// NewFactory creates a new service factory using the provided load function.
 //
-// The load function must be a function. It may accept dependencies as input parameters and return
-// exactly one service instances, optionally followed by an error as the second return value.
-//
-// Example:
+// The load function may accept dependencies as input parameters and must return
+// exactly one service instance, optionally followed by a cleanup callback and/or
+// an error. The supported signatures are:
 //
 //	gontainer.NewFactory(func(db *Database) *Handler { ... })
 //	gontainer.NewFactory(func(db *Database) (*Handler, error) { ... })
 //	gontainer.NewFactory(func(db *Database) (*Handler, func() error) { ... })
 //	gontainer.NewFactory(func(db *Database) (*Handler, func() error, error) { ... })
+//
+// NewFactory validates its function argument at the public API boundary and
+// panics on a programmer error: when function is an untyped nil, is not a
+// function, is a typed nil function, or has an unsupported signature. Failures
+// that occur later for a valid factory (during dependency resolution, graph construction,
+// factory execution, or cleanup) are reported as an error from Run, never as a panic.
 func NewFactory(function any, opts ...FactoryOption) *Factory {
-	funcValue := reflect.ValueOf(function)
+	// Examples of valid factory functions, shown to the caller on misuse.
+	const examples = "Valid usage:\n" +
+		"  gontainer.NewFactory(func(/* deps */) *Service { ... })\n" +
+		"  gontainer.NewFactory(func(/* deps */) (*Service, error) { ... })\n" +
+		"  gontainer.NewFactory(func(/* deps */) (*Service, func() error) { ... })\n" +
+		"  gontainer.NewFactory(func(/* deps */) (*Service, func() error, error) { ... })"
+
+	// Validate the function is not a nil.
 	funcType := reflect.TypeOf(function)
+	if funcType == nil {
+		panic(fmt.Sprintf("%s NewFactory: expected a function, got nil\n\n%s", panicPrefix, examples))
+	}
+
+	// Validate the function type is a function.
+	if funcType.Kind() != reflect.Func {
+		panic(fmt.Sprintf("%s NewFactory: expected a function, got %s\n\n%s", panicPrefix, funcType, examples))
+	}
+
+	// Validate the function value is not a typed nil.
+	funcValue := reflect.ValueOf(function)
+	if funcValue.IsNil() {
+		panic(fmt.Sprintf("%s NewFactory: expected a non-nil function, got nil %s\n\n%s", panicPrefix, funcType, examples))
+	}
 
 	// Prepare factory description.
-	name := fmt.Sprintf("Factory[%s]", funcValue.Type())
+	name := fmt.Sprintf("Factory[%s]", funcType)
 	source := getCallerSource(1)
 
 	// Prepare factory settings.
@@ -118,58 +144,53 @@ func NewFactory(function any, opts ...FactoryOption) *Factory {
 		opt.applyFactory(&settings)
 	}
 
+	// Prepare default value and error getters.
+	var getOutType getOutTypeFn
+	var getOutValue getOutValueFn
+	var getOutClose getOutCloseFn
+	var getOutError getOutErrorFn
+
+	// Prepare value and error getters.
+	switch {
+	// Factory returns exactly one service.
+	case funcType.NumOut() == 1 && !isEmptyInterface(funcType.Out(0)) && !isErrorInterface(funcType.Out(0)):
+		getOutType = func(outTypes []reflect.Type) reflect.Type { return outTypes[0] }
+		getOutValue = func(outValues []reflect.Value) reflect.Value { return outValues[0] }
+		getOutClose = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
+		getOutError = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
+
+	// Factory returns a service and an error.
+	case funcType.NumOut() == 2 && !isEmptyInterface(funcType.Out(0)) && !isErrorInterface(funcType.Out(0)) && isErrorInterface(funcType.Out(1)):
+		getOutType = func(outTypes []reflect.Type) reflect.Type { return outTypes[0] }
+		getOutValue = func(outValues []reflect.Value) reflect.Value { return outValues[0] }
+		getOutClose = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
+		getOutError = func(outValues []reflect.Value) reflect.Value { return outValues[1] }
+
+	// Factory returns a service and a close callback.
+	case funcType.NumOut() == 2 && !isEmptyInterface(funcType.Out(0)) && !isErrorInterface(funcType.Out(0)) && isCloseCallback(funcType.Out(1)):
+		getOutType = func(outTypes []reflect.Type) reflect.Type { return outTypes[0] }
+		getOutValue = func(outValues []reflect.Value) reflect.Value { return outValues[0] }
+		getOutClose = func(outValues []reflect.Value) reflect.Value { return outValues[1] }
+		getOutError = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
+
+	// Factory returns a service, a close callback and an error.
+	case funcType.NumOut() == 3 && !isEmptyInterface(funcType.Out(0)) && !isErrorInterface(funcType.Out(0)) && isCloseCallback(funcType.Out(1)) && isErrorInterface(funcType.Out(2)):
+		getOutType = func(outTypes []reflect.Type) reflect.Type { return outTypes[0] }
+		getOutValue = func(outValues []reflect.Value) reflect.Value { return outValues[0] }
+		getOutClose = func(outValues []reflect.Value) reflect.Value { return outValues[1] }
+		getOutError = func(outValues []reflect.Value) reflect.Value { return outValues[2] }
+
+	// Factory signature is unsupported.
+	default:
+		panic(fmt.Sprintf("%s NewFactory: unsupported function signature %s\n\n%s", panicPrefix, funcType, examples))
+	}
+
 	// Prepare factory instance.
 	return &Factory{
 		name:        name,
 		source:      source,
 		annotations: settings.annotations,
 		register: func(registry *registry) error {
-			// Validate function type.
-			if funcType.Kind() != reflect.Func {
-				return fmt.Errorf("invalid type: %s", funcType)
-			}
-
-			// Prepare default value and error getters.
-			var getOutType getOutTypeFn
-			var getOutValue getOutValueFn
-			var getOutClose getOutCloseFn
-			var getOutError getOutErrorFn
-
-			// Prepare value and error getters.
-			switch {
-			// Factory returns exactly one service.
-			case funcType.NumOut() == 1 && !isEmptyInterface(funcType.Out(0)) && !isErrorInterface(funcType.Out(0)):
-				getOutType = func(outTypes []reflect.Type) reflect.Type { return outTypes[0] }
-				getOutValue = func(outValues []reflect.Value) reflect.Value { return outValues[0] }
-				getOutClose = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
-				getOutError = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
-
-			// Factory returns a service and an error.
-			case funcType.NumOut() == 2 && !isEmptyInterface(funcType.Out(0)) && !isErrorInterface(funcType.Out(0)) && isErrorInterface(funcType.Out(1)):
-				getOutType = func(outTypes []reflect.Type) reflect.Type { return outTypes[0] }
-				getOutValue = func(outValues []reflect.Value) reflect.Value { return outValues[0] }
-				getOutClose = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
-				getOutError = func(outValues []reflect.Value) reflect.Value { return outValues[1] }
-
-			// Factory returns a service and a close callback.
-			case funcType.NumOut() == 2 && !isEmptyInterface(funcType.Out(0)) && !isErrorInterface(funcType.Out(0)) && isCloseCallback(funcType.Out(1)):
-				getOutType = func(outTypes []reflect.Type) reflect.Type { return outTypes[0] }
-				getOutValue = func(outValues []reflect.Value) reflect.Value { return outValues[0] }
-				getOutClose = func(outValues []reflect.Value) reflect.Value { return outValues[1] }
-				getOutError = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
-
-			// Factory returns a service, a close callback and an error.
-			case funcType.NumOut() == 3 && !isEmptyInterface(funcType.Out(0)) && !isErrorInterface(funcType.Out(0)) && isCloseCallback(funcType.Out(1)) && isErrorInterface(funcType.Out(2)):
-				getOutType = func(outTypes []reflect.Type) reflect.Type { return outTypes[0] }
-				getOutValue = func(outValues []reflect.Value) reflect.Value { return outValues[0] }
-				getOutClose = func(outValues []reflect.Value) reflect.Value { return outValues[1] }
-				getOutError = func(outValues []reflect.Value) reflect.Value { return outValues[2] }
-
-			// Factory signature is invalid.
-			default:
-				return fmt.Errorf("invalid signature: %s", funcType)
-			}
-
 			// Load the factory internal representation.
 			state, err := newFactory(
 				kindFactory, name, source, funcValue,
@@ -289,18 +310,45 @@ func (s *factorySettings) appendAnnotation(value any) {
 	s.annotations = append(s.annotations, value)
 }
 
-// NewEntrypoint creates a new factory which will be called by the container.
+// NewEntrypoint creates a new entrypoint function which will be called by the container.
 //
-// Example:
+// The entrypoint function may accept dependencies as input parameters and must
+// return nothing or a single error. The supported signatures are:
 //
-//	gontainer.NewEntrypoint(func(db *Database) error { ... })
 //	gontainer.NewEntrypoint(func(db *Database) { ... })
+//	gontainer.NewEntrypoint(func(db *Database) error { ... })
+//
+// NewEntrypoint validates its function argument at the public API boundary and
+// panics on a programmer error: when function is an untyped nil, is not a
+// function, is a typed nil function, or has an unsupported signature. Every
+// panic message is prefixed with "gontainer:". Failures that occur later for a
+// valid entrypoint (during dependency resolution or entrypoint execution) are
+// reported as an error from Run, never as a panic.
 func NewEntrypoint(function any, opts ...EntrypointOption) *Entrypoint {
-	funcValue := reflect.ValueOf(function)
+	// Examples of valid entrypoint functions, shown to the caller on misuse.
+	const examples = "Valid usage:\n" +
+		"  gontainer.NewEntrypoint(func(/* deps */) { ... })\n" +
+		"  gontainer.NewEntrypoint(func(/* deps */) error { ... })"
+
+	// Validate the function is not a nil.
 	funcType := reflect.TypeOf(function)
+	if funcType == nil {
+		panic(fmt.Sprintf("%s NewEntrypoint: expected a function, got nil\n\n%s", panicPrefix, examples))
+	}
+
+	// Validate the function type is a function.
+	if funcType.Kind() != reflect.Func {
+		panic(fmt.Sprintf("%s NewEntrypoint: expected a function, got %s\n\n%s", panicPrefix, funcType, examples))
+	}
+
+	// Validate the function value is not a typed nil.
+	funcValue := reflect.ValueOf(function)
+	if funcValue.IsNil() {
+		panic(fmt.Sprintf("%s NewEntrypoint: expected a non-nil function, got nil %s\n\n%s", panicPrefix, funcType, examples))
+	}
 
 	// Prepare entrypoint description.
-	name := fmt.Sprintf("Entrypoint[%s]", funcValue.Type())
+	name := fmt.Sprintf("Entrypoint[%s]", funcType)
 	source := getCallerSource(1)
 
 	// Prepare entrypoint settings.
@@ -309,44 +357,40 @@ func NewEntrypoint(function any, opts ...EntrypointOption) *Entrypoint {
 		opt.applyEntrypoint(&settings)
 	}
 
+	// Prepare default value and error getters.
+	var getOutType getOutTypeFn
+	var getOutValue getOutValueFn
+	var getOutClose getOutCloseFn
+	var getOutError getOutErrorFn
+
+	// Resolve the output getters for the supported entrypoint signatures,
+	// rejecting any unsupported signature at the public API boundary.
+	switch {
+	// Function returns nothing.
+	case funcType.NumOut() == 0:
+		getOutType = func(outTypes []reflect.Type) reflect.Type { return nil }
+		getOutValue = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
+		getOutClose = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
+		getOutError = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
+
+	// Function returns an error.
+	case funcType.NumOut() == 1 && isErrorInterface(funcType.Out(0)):
+		getOutType = func(outTypes []reflect.Type) reflect.Type { return nil }
+		getOutValue = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
+		getOutClose = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
+		getOutError = func(outValues []reflect.Value) reflect.Value { return outValues[0] }
+
+	// Function signature is unsupported.
+	default:
+		panic(fmt.Sprintf("%s NewEntrypoint: unsupported function signature %s\n\n%s", panicPrefix, funcType, examples))
+	}
+
 	// Prepare entrypoint instance.
 	return &Entrypoint{
 		name:        name,
 		source:      source,
 		annotations: settings.annotations,
 		register: func(registry *registry) error {
-			// Validate function type.
-			if funcType.Kind() != reflect.Func {
-				return fmt.Errorf("invalid type: %s", funcType)
-			}
-
-			// Prepare default value and error getters.
-			var getOutType getOutTypeFn
-			var getOutValue getOutValueFn
-			var getOutClose getOutCloseFn
-			var getOutError getOutErrorFn
-
-			// Prepare value and error getters.
-			switch {
-			// Function returns nothing.
-			case funcType.NumOut() == 0:
-				getOutType = func(outTypes []reflect.Type) reflect.Type { return nil }
-				getOutValue = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
-				getOutClose = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
-				getOutError = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
-
-			// Function returns an error.
-			case funcType.NumOut() == 1 && isErrorInterface(funcType.Out(0)):
-				getOutType = func(outTypes []reflect.Type) reflect.Type { return nil }
-				getOutValue = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
-				getOutClose = func(outValues []reflect.Value) reflect.Value { return reflect.Value{} }
-				getOutError = func(outValues []reflect.Value) reflect.Value { return outValues[0] }
-
-			// Function signature is invalid.
-			default:
-				return fmt.Errorf("invalid signature: %s", funcType)
-			}
-
 			// Load the factory internal representation.
 			state, err := newFactory(
 				kindEntrypoint, name, source, funcValue,

--- a/container.go
+++ b/container.go
@@ -104,11 +104,11 @@ type Option interface {
 //	gontainer.NewFactory(func(/* deps */) (*Service, func() error) { ... })
 //	gontainer.NewFactory(func(/* deps */) (*Service, func() error, error) { ... })
 //
-// NewFactory validates its function argument at the public API boundary and
-// panics on a programmer error: when function is an untyped nil, is not a
-// function, is a typed nil function, or has an unsupported signature. Failures
-// that occur later for a valid factory (during dependency resolution, graph construction,
-// factory execution, or cleanup) are reported as an error from Run, never as a panic.
+// NewFactory validates its function argument eagerly and panics on a programmer
+// error: when function is an untyped nil, is not a function, is a typed nil
+// function, or has an unsupported signature. Failures that occur later for a
+// valid factory (during dependency resolution, graph construction, factory
+// execution, or cleanup) are reported as an error from Run, never as a panic.
 func NewFactory(function any, opts ...FactoryOption) *Factory {
 	// Examples shown to the caller on misuse.
 	const examples = "Valid usage:\n" +
@@ -318,10 +318,10 @@ func (s *factorySettings) appendAnnotation(value any) {
 //	gontainer.NewEntrypoint(func(/* deps */) { ... })
 //	gontainer.NewEntrypoint(func(/* deps */) error { ... })
 //
-// NewEntrypoint validates its function argument at the public API boundary and
-// panics on a programmer error: when function is an untyped nil, is not a
-// function, is a typed nil function, or has an unsupported signature. Failures
-// that occur later for a valid entrypoint (during dependency resolution or entrypoint
+// NewEntrypoint validates its function argument eagerly and panics on a
+// programmer error: when function is an untyped nil, is not a function, is a
+// typed nil function, or has an unsupported signature. Failures that occur
+// later for a valid entrypoint (during dependency resolution or entrypoint
 // execution) are reported as an error from Run, never as a panic.
 func NewEntrypoint(function any, opts ...EntrypointOption) *Entrypoint {
 	// Examples shown to the caller on misuse.

--- a/container.go
+++ b/container.go
@@ -117,7 +117,7 @@ func NewFactory(function any, opts ...FactoryOption) *Factory {
 		"  gontainer.NewFactory(func(/* deps */) (*Service, func() error) { ... })\n" +
 		"  gontainer.NewFactory(func(/* deps */) (*Service, func() error, error) { ... })"
 
-	// Validate the function is not a nil.
+	// Validate the function is not nil.
 	funcType := reflect.TypeOf(function)
 	if funcType == nil {
 		panic(fmt.Sprintf("%s NewFactory: expected a function, got nil\n\n%s", panicPrefix, examples))
@@ -329,7 +329,7 @@ func NewEntrypoint(function any, opts ...EntrypointOption) *Entrypoint {
 		"  gontainer.NewEntrypoint(func(/* deps */) { ... })\n" +
 		"  gontainer.NewEntrypoint(func(/* deps */) error { ... })"
 
-	// Validate the function is not a nil.
+	// Validate the function is not nil.
 	funcType := reflect.TypeOf(function)
 	if funcType == nil {
 		panic(fmt.Sprintf("%s NewEntrypoint: expected a function, got nil\n\n%s", panicPrefix, examples))

--- a/container.go
+++ b/container.go
@@ -99,10 +99,10 @@ type Option interface {
 // exactly one service instance, optionally followed by a cleanup callback and/or
 // an error. The supported signatures are:
 //
-//	gontainer.NewFactory(func(db *Database) *Handler { ... })
-//	gontainer.NewFactory(func(db *Database) (*Handler, error) { ... })
-//	gontainer.NewFactory(func(db *Database) (*Handler, func() error) { ... })
-//	gontainer.NewFactory(func(db *Database) (*Handler, func() error, error) { ... })
+//	gontainer.NewFactory(func(/* deps */) *Service { ... })
+//	gontainer.NewFactory(func(/* deps */) (*Service, error) { ... })
+//	gontainer.NewFactory(func(/* deps */) (*Service, func() error) { ... })
+//	gontainer.NewFactory(func(/* deps */) (*Service, func() error, error) { ... })
 //
 // NewFactory validates its function argument at the public API boundary and
 // panics on a programmer error: when function is an untyped nil, is not a
@@ -315,8 +315,8 @@ func (s *factorySettings) appendAnnotation(value any) {
 // The entrypoint function may accept dependencies as input parameters and must
 // return nothing or a single error. The supported signatures are:
 //
-//	gontainer.NewEntrypoint(func(db *Database) { ... })
-//	gontainer.NewEntrypoint(func(db *Database) error { ... })
+//	gontainer.NewEntrypoint(func(/* deps */) { ... })
+//	gontainer.NewEntrypoint(func(/* deps */) error { ... })
 //
 // NewEntrypoint validates its function argument at the public API boundary and
 // panics on a programmer error: when function is an untyped nil, is not a

--- a/container.go
+++ b/container.go
@@ -110,7 +110,7 @@ type Option interface {
 // that occur later for a valid factory (during dependency resolution, graph construction,
 // factory execution, or cleanup) are reported as an error from Run, never as a panic.
 func NewFactory(function any, opts ...FactoryOption) *Factory {
-	// Examples of valid factory functions, shown to the caller on misuse.
+	// Examples shown to the caller on misuse.
 	const examples = "Valid usage:\n" +
 		"  gontainer.NewFactory(func(/* deps */) *Service { ... })\n" +
 		"  gontainer.NewFactory(func(/* deps */) (*Service, error) { ... })\n" +
@@ -320,12 +320,11 @@ func (s *factorySettings) appendAnnotation(value any) {
 //
 // NewEntrypoint validates its function argument at the public API boundary and
 // panics on a programmer error: when function is an untyped nil, is not a
-// function, is a typed nil function, or has an unsupported signature. Every
-// panic message is prefixed with "gontainer:". Failures that occur later for a
-// valid entrypoint (during dependency resolution or entrypoint execution) are
-// reported as an error from Run, never as a panic.
+// function, is a typed nil function, or has an unsupported signature. Failures
+// that occur later for a valid entrypoint (during dependency resolution or entrypoint
+// execution) are reported as an error from Run, never as a panic.
 func NewEntrypoint(function any, opts ...EntrypointOption) *Entrypoint {
-	// Examples of valid entrypoint functions, shown to the caller on misuse.
+	// Examples shown to the caller on misuse.
 	const examples = "Valid usage:\n" +
 		"  gontainer.NewEntrypoint(func(/* deps */) { ... })\n" +
 		"  gontainer.NewEntrypoint(func(/* deps */) error { ... })"
@@ -363,8 +362,7 @@ func NewEntrypoint(function any, opts ...EntrypointOption) *Entrypoint {
 	var getOutClose getOutCloseFn
 	var getOutError getOutErrorFn
 
-	// Resolve the output getters for the supported entrypoint signatures,
-	// rejecting any unsupported signature at the public API boundary.
+	// Prepare value and error getters.
 	switch {
 	// Function returns nothing.
 	case funcType.NumOut() == 0:

--- a/container_test.go
+++ b/container_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"strings"
 	"sync/atomic"
 	"testing"
 )
@@ -122,6 +123,142 @@ func equal(t *testing.T, a, b any) {
 	t.Helper()
 	if !reflect.DeepEqual(a, b) {
 		t.Fatalf("equal failed: '%v' != '%v'", a, b)
+	}
+}
+
+// assertPanics runs call and fails the test unless it panics with a string value
+// that starts with the shared "gontainer:" prefix and contains want.
+func assertPanics(t *testing.T, want string, call func()) {
+	t.Helper()
+	defer func() {
+		// Recover the propagated panic so the test process survives.
+		recovered := recover()
+		if recovered == nil {
+			t.Fatalf("expected panic containing %q, got no panic", want)
+		}
+
+		// Every programmer-error panic must be a plain, prefixed string.
+		message, ok := recovered.(string)
+		if !ok {
+			t.Fatalf("expected string panic, got %T: %v", recovered, recovered)
+		}
+		if !strings.HasPrefix(message, panicPrefix) {
+			t.Fatalf("expected panic prefixed with %q, got %q", panicPrefix, message)
+		}
+		if !strings.Contains(message, want) {
+			t.Fatalf("expected panic containing %q, got %q", want, message)
+		}
+	}()
+	call()
+}
+
+// TestNewFactoryPanics verifies that NewFactory rejects invalid arguments with a
+// stable, gontainer-prefixed panic instead of returning an error or leaking a
+// reflect panic.
+func TestNewFactoryPanics(t *testing.T) {
+	// A typed nil factory function exercises the typed nil rejection path.
+	var nilFactoryFunc func() *testService1
+
+	tests := []struct {
+		name string
+		call func()
+		want string
+	}{
+		{
+			name: "UntypedNil",
+			call: func() { NewFactory(nil) },
+			want: "expected a function, got nil",
+		},
+		{
+			name: "NonFunctionValue",
+			call: func() { NewFactory(42) },
+			want: "expected a function, got int",
+		},
+		{
+			name: "TypedNilFunction",
+			call: func() { NewFactory(nilFactoryFunc) },
+			want: "expected a non-nil function",
+		},
+		{
+			name: "SignatureNoResults",
+			call: func() { NewFactory(func() {}) },
+			want: "unsupported function signature",
+		},
+		{
+			name: "SignatureOnlyError",
+			call: func() { NewFactory(func() error { return nil }) },
+			want: "unsupported function signature",
+		},
+		{
+			name: "SignatureEmptyInterface",
+			call: func() { NewFactory(func() any { return nil }) },
+			want: "unsupported function signature",
+		},
+		{
+			name: "SignatureTwoServices",
+			call: func() { NewFactory(func() (int, string) { return 0, "" }) },
+			want: "unsupported function signature",
+		},
+		{
+			name: "SignatureErrorFirst",
+			call: func() { NewFactory(func() (error, int) { return nil, 0 }) },
+			want: "unsupported function signature",
+		},
+		{
+			name: "SignatureTooManyResults",
+			call: func() { NewFactory(func() (int, func() error, error, bool) { return 0, nil, nil, false }) },
+			want: "unsupported function signature",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertPanics(t, tt.want, tt.call)
+		})
+	}
+}
+
+// TestNewEntrypointPanics verifies that NewEntrypoint rejects invalid arguments
+// with a stable, gontainer-prefixed panic instead of returning an error or
+// leaking a reflect panic.
+func TestNewEntrypointPanics(t *testing.T) {
+	// A typed nil entrypoint function exercises the typed nil rejection path.
+	var nilEntrypointFunc func() error
+
+	tests := []struct {
+		name string
+		call func()
+		want string
+	}{
+		{
+			name: "UntypedNil",
+			call: func() { NewEntrypoint(nil) },
+			want: "expected a function, got nil",
+		},
+		{
+			name: "NonFunctionValue",
+			call: func() { NewEntrypoint("not-a-func") },
+			want: "expected a function, got string",
+		},
+		{
+			name: "TypedNilFunction",
+			call: func() { NewEntrypoint(nilEntrypointFunc) },
+			want: "expected a non-nil function",
+		},
+		{
+			name: "SignatureNonErrorResult",
+			call: func() { NewEntrypoint(func() int { return 0 }) },
+			want: "unsupported function signature",
+		},
+		{
+			name: "SignatureTwoResults",
+			call: func() { NewEntrypoint(func() (int, error) { return 0, nil }) },
+			want: "unsupported function signature",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertPanics(t, tt.want, tt.call)
+		})
 	}
 }
 

--- a/errors.go
+++ b/errors.go
@@ -24,6 +24,10 @@ import (
 	"strings"
 )
 
+// panicPrefix is the stable prefix shared by every programmer-error panic so
+// callers can reliably recognize a gontainer misuse panic.
+const panicPrefix = "gontainer:"
+
 // ErrFactoryTypeDuplicated declares service duplicated error.
 var ErrFactoryTypeDuplicated = errors.New("factory type duplicated")
 

--- a/invoker.go
+++ b/invoker.go
@@ -52,7 +52,7 @@ type Invoker struct {
 // a dependency cannot be resolved; errors produced by the function itself are returned
 // among the []any results, not as the error.
 func (i *Invoker) Invoke(function any) ([]any, error) {
-	// Validate the function is not a nil.
+	// Validate the function is not nil.
 	funcType := reflect.TypeOf(function)
 	if funcType == nil {
 		panic(fmt.Sprintf("%s Invoker.Invoke: expected a function, got nil", panicPrefix))

--- a/invoker.go
+++ b/invoker.go
@@ -24,7 +24,7 @@ import (
 
 // Invoker invokes functions with automatic dependency resolution.
 //
-// The Invoke method accepts a function `fn`, resolves its input parameters using the invoker's
+// The Invoke method accepts a function, resolves its input parameters using the invoker's
 // dependency resolver, and then calls the function with the resolved arguments.
 //
 // If the container has not been started yet, dependency resolution happens in lazy mode — only
@@ -32,22 +32,39 @@ import (
 //
 // The Invoke method returns:
 //   - []any - all values returned by the function (including any errors)
-//   - error - only if dependency resolution fails or fn is not a function
+//   - error - only if dependency resolution fails
 //
 // All return values from the invoked function are collected in the []any slice,
 // including any error values. The caller is responsible for checking and handling
 // these values as appropriate.
+//
+// Invoke panics when its function argument is not a valid, non-nil function; see
+// the Invoke method for details.
 type Invoker struct {
 	registry *registry
 }
 
-// Invoke invokes specified function.
+// Invoke invokes the specified function with dependencies resolved from the container.
+//
+// Invoke validates its function argument at the public API boundary and panics
+// on a programmer error: when function is an untyped nil, is not a function, or
+// is a typed nil function. The panic message is prefixed with "gontainer:". For
+// a valid function, Invoke returns an error only when a dependency cannot be
+// resolved; errors produced by the function itself are returned among the []any
+// results, not as the error.
 func (i *Invoker) Invoke(function any) ([]any, error) {
-	// Get reflection of the function.
-	funcValue := reflect.ValueOf(function)
+	// Validate the function at the public API boundary, rejecting an untyped nil,
+	// a non-function, or a typed nil function with a clear message.
 	funcType := reflect.TypeOf(function)
-	if funcType == nil || funcType.Kind() != reflect.Func {
-		return nil, fmt.Errorf("invalid type: %v", funcType)
+	if funcType == nil {
+		panic(fmt.Sprintf("%s Invoker.Invoke: expected a function, got nil", panicPrefix))
+	}
+	if funcType.Kind() != reflect.Func {
+		panic(fmt.Sprintf("%s Invoker.Invoke: expected a function, got %s", panicPrefix, funcType))
+	}
+	funcValue := reflect.ValueOf(function)
+	if funcValue.IsNil() {
+		panic(fmt.Sprintf("%s Invoker.Invoke: expected a non-nil function, got nil %s", panicPrefix, funcType))
 	}
 
 	// Resolve function arguments.

--- a/invoker.go
+++ b/invoker.go
@@ -46,11 +46,10 @@ type Invoker struct {
 
 // Invoke invokes the specified function with dependencies resolved from the container.
 //
-// Invoke validates its function argument at the public API boundary and panics
-// on a programmer error: when function is an untyped nil, is not a function, or
-// is a typed nil function. For a valid function, Invoke returns an error only when
-// a dependency cannot be resolved; errors produced by the function itself are returned
-// among the []any results, not as the error.
+// Invoke validates its function argument eagerly and panics on a programmer error: when
+// function is an untyped nil, is not a function, or is a typed nil function. For a valid
+// function, Invoke returns an error only when a dependency cannot be resolved; errors
+// produced by the function itself are returned among the []any results, not as the error.
 func (i *Invoker) Invoke(function any) ([]any, error) {
 	// Validate the function is not nil.
 	funcType := reflect.TypeOf(function)

--- a/invoker.go
+++ b/invoker.go
@@ -48,10 +48,9 @@ type Invoker struct {
 //
 // Invoke validates its function argument at the public API boundary and panics
 // on a programmer error: when function is an untyped nil, is not a function, or
-// is a typed nil function. The panic message is prefixed with "gontainer:". For
-// a valid function, Invoke returns an error only when a dependency cannot be
-// resolved; errors produced by the function itself are returned among the []any
-// results, not as the error.
+// is a typed nil function. For a valid function, Invoke returns an error only when
+// a dependency cannot be resolved; errors produced by the function itself are returned
+// among the []any results, not as the error.
 func (i *Invoker) Invoke(function any) ([]any, error) {
 	// Validate the function is not a nil.
 	funcType := reflect.TypeOf(function)

--- a/invoker.go
+++ b/invoker.go
@@ -53,15 +53,18 @@ type Invoker struct {
 // resolved; errors produced by the function itself are returned among the []any
 // results, not as the error.
 func (i *Invoker) Invoke(function any) ([]any, error) {
-	// Validate the function at the public API boundary, rejecting an untyped nil,
-	// a non-function, or a typed nil function with a clear message.
+	// Validate the function is not a nil.
 	funcType := reflect.TypeOf(function)
 	if funcType == nil {
 		panic(fmt.Sprintf("%s Invoker.Invoke: expected a function, got nil", panicPrefix))
 	}
+
+	// Validate the function type is a function.
 	if funcType.Kind() != reflect.Func {
 		panic(fmt.Sprintf("%s Invoker.Invoke: expected a function, got %s", panicPrefix, funcType))
 	}
+
+	// Validate the function value is not a typed nil.
 	funcValue := reflect.ValueOf(function)
 	if funcValue.IsNil() {
 		panic(fmt.Sprintf("%s Invoker.Invoke: expected a non-nil function, got nil %s", panicPrefix, funcType))

--- a/invoker_test.go
+++ b/invoker_test.go
@@ -89,14 +89,10 @@ func TestInvokerService(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "InvokeNilReturnsError",
-			haveFn:  nil,
-			wantFn:  nil,
-			wantErr: true,
-		},
-		{
-			name:    "InvokeNonFuncReturnsError",
-			haveFn:  42,
+			// A well-formed function whose dependency is unregistered must
+			// surface the failure as an error rather than a panic.
+			name:    "UnresolvedDependencyReturnsError",
+			haveFn:  func(dep float64) {},
 			wantFn:  nil,
 			wantErr: true,
 		},
@@ -128,4 +124,52 @@ func TestInvokerService(t *testing.T) {
 			equal(t, started.Load(), true)
 		})
 	}
+}
+
+// TestInvokerInvokePanics verifies that Invoker.Invoke rejects invalid function
+// arguments with a stable, gontainer-prefixed panic instead of returning an
+// error or leaking a reflect panic.
+func TestInvokerInvokePanics(t *testing.T) {
+	invoker := &Invoker{registry: &registry{}}
+
+	// A typed nil invoker function exercises the typed nil rejection path.
+	var nilInvokeFunc func()
+
+	tests := []struct {
+		name string
+		call func()
+		want string
+	}{
+		{
+			name: "UntypedNil",
+			call: func() { _, _ = invoker.Invoke(nil) },
+			want: "expected a function, got nil",
+		},
+		{
+			name: "NonFunctionValue",
+			call: func() { _, _ = invoker.Invoke(42) },
+			want: "expected a function, got int",
+		},
+		{
+			name: "TypedNilFunction",
+			call: func() { _, _ = invoker.Invoke(nilInvokeFunc) },
+			want: "expected a non-nil function",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertPanics(t, tt.want, tt.call)
+		})
+	}
+}
+
+// TestInvokerInvokeValidReturnsError verifies that a valid function never panics:
+// an unresolved dependency is surfaced as an error for well-formed input.
+func TestInvokerInvokeValidReturnsError(t *testing.T) {
+	invoker := &Invoker{registry: &registry{}}
+
+	// A valid function whose dependency is unregistered must return an error.
+	values, err := invoker.Invoke(func(dep *testService1) {})
+	equal(t, values, []any(nil))
+	equal(t, err != nil, true)
 }

--- a/resolver.go
+++ b/resolver.go
@@ -18,30 +18,59 @@
 package gontainer
 
 import (
+	"fmt"
 	"reflect"
 )
 
 // Resolver resolves service dependencies.
 //
-// The Resolve method accepts a pointer to a variable (`varPtr`) and attempts to populate it
-// with an instance of the requested type. The type is determined via reflection based on the
-// element type of `varPtr`.
+// The Resolve method accepts a non-nil pointer to a variable and populates it with an instance
+// of the requested type. The type is determined via reflection from the element the pointer
+// refers to.
 //
 // If the container has not been started yet, Resolve operates in lazy mode — it instantiates
 // only the requested type and its transitive dependencies on demand.
 //
-// An error is returned if the service of the requested type is not found or cannot be resolved.
+// Resolve panics when its target argument is not a valid, non-nil, writable pointer; see the
+// Resolve method for details. For a valid pointer, an error is returned if the service of the
+// requested type is not found or cannot be resolved.
 type Resolver struct {
 	registry *registry
 }
 
-// Resolve sets the required dependency via the pointer.
-func (r *Resolver) Resolve(varPtr any) error {
-	value := reflect.ValueOf(varPtr).Elem()
+// Resolve populates the target variable with the resolved service.
+//
+// Resolve validates its target argument at the public API boundary and panics on
+// a programmer error: when target is an untyped nil, is not a pointer, is a nil
+// pointer, or points to a value that cannot be set. The panic message is prefixed
+// with "gontainer:". For a valid pointer, Resolve returns an error when the
+// requested service is not found or cannot be resolved.
+func (r *Resolver) Resolve(target any) error {
+	// Validate the target at the public API boundary, rejecting an untyped nil, a
+	// non-pointer, a nil pointer, or a pointer to a non-writable value.
+	pointerType := reflect.TypeOf(target)
+	if pointerType == nil {
+		panic(fmt.Sprintf("%s Resolver.Resolve: expected a non-nil pointer, got nil", panicPrefix))
+	}
+	if pointerType.Kind() != reflect.Pointer {
+		panic(fmt.Sprintf("%s Resolver.Resolve: expected a non-nil pointer, got %s", panicPrefix, pointerType))
+	}
+	pointerValue := reflect.ValueOf(target)
+	if pointerValue.IsNil() {
+		panic(fmt.Sprintf("%s Resolver.Resolve: expected a non-nil pointer, got nil %s", panicPrefix, pointerType))
+	}
+	value := pointerValue.Elem()
+	if !value.CanSet() {
+		panic(fmt.Sprintf("%s Resolver.Resolve: expected a pointer to a writable value, got %s", panicPrefix, pointerType))
+	}
+
+	// Resolve the service by the target element type.
 	result, err := r.registry.resolveService(value.Type())
 	if err != nil {
 		return err
 	}
+
+	// Populate the target with the resolved service.
 	value.Set(result)
 	return nil
 }

--- a/resolver.go
+++ b/resolver.go
@@ -45,7 +45,7 @@ type Resolver struct {
 // pointer, or points to a value that cannot be set. For a valid pointer, Resolve
 // returns an error when the requested service is not found or cannot be resolved.
 func (r *Resolver) Resolve(target any) error {
-	// Validate the target is not a nil.
+	// Validate the target is not nil.
 	pointerType := reflect.TypeOf(target)
 	if pointerType == nil {
 		panic(fmt.Sprintf("%s Resolver.Resolve: expected a non-nil pointer, got nil", panicPrefix))
@@ -62,7 +62,7 @@ func (r *Resolver) Resolve(target any) error {
 		panic(fmt.Sprintf("%s Resolver.Resolve: expected a non-nil pointer, got nil %s", panicPrefix, pointerType))
 	}
 
-	// Validate the target value is a writable value.
+	// Validate the target points to a writable value.
 	value := pointerValue.Elem()
 	if !value.CanSet() {
 		panic(fmt.Sprintf("%s Resolver.Resolve: expected a pointer to a writable value, got %s", panicPrefix, pointerType))

--- a/resolver.go
+++ b/resolver.go
@@ -46,19 +46,24 @@ type Resolver struct {
 // with "gontainer:". For a valid pointer, Resolve returns an error when the
 // requested service is not found or cannot be resolved.
 func (r *Resolver) Resolve(target any) error {
-	// Validate the target at the public API boundary, rejecting an untyped nil, a
-	// non-pointer, a nil pointer, or a pointer to a non-writable value.
+	// Validate the target is not a nil.
 	pointerType := reflect.TypeOf(target)
 	if pointerType == nil {
 		panic(fmt.Sprintf("%s Resolver.Resolve: expected a non-nil pointer, got nil", panicPrefix))
 	}
+
+	// Validate the target type is a pointer.
 	if pointerType.Kind() != reflect.Pointer {
 		panic(fmt.Sprintf("%s Resolver.Resolve: expected a non-nil pointer, got %s", panicPrefix, pointerType))
 	}
+
+	// Validate the target value is not a nil pointer.
 	pointerValue := reflect.ValueOf(target)
 	if pointerValue.IsNil() {
 		panic(fmt.Sprintf("%s Resolver.Resolve: expected a non-nil pointer, got nil %s", panicPrefix, pointerType))
 	}
+
+	// Validate the target value is a writable value.
 	value := pointerValue.Elem()
 	if !value.CanSet() {
 		panic(fmt.Sprintf("%s Resolver.Resolve: expected a pointer to a writable value, got %s", panicPrefix, pointerType))

--- a/resolver.go
+++ b/resolver.go
@@ -42,9 +42,8 @@ type Resolver struct {
 //
 // Resolve validates its target argument at the public API boundary and panics on
 // a programmer error: when target is an untyped nil, is not a pointer, is a nil
-// pointer, or points to a value that cannot be set. The panic message is prefixed
-// with "gontainer:". For a valid pointer, Resolve returns an error when the
-// requested service is not found or cannot be resolved.
+// pointer, or points to a value that cannot be set. For a valid pointer, Resolve
+// returns an error when the requested service is not found or cannot be resolved.
 func (r *Resolver) Resolve(target any) error {
 	// Validate the target is not a nil.
 	pointerType := reflect.TypeOf(target)

--- a/resolver.go
+++ b/resolver.go
@@ -40,10 +40,10 @@ type Resolver struct {
 
 // Resolve populates the target variable with the resolved service.
 //
-// Resolve validates its target argument at the public API boundary and panics on
-// a programmer error: when target is an untyped nil, is not a pointer, is a nil
-// pointer, or points to a value that cannot be set. For a valid pointer, Resolve
-// returns an error when the requested service is not found or cannot be resolved.
+// Resolve validates its target argument eagerly and panics on a programmer error: when target
+// is an untyped nil, is not a pointer, is a nil pointer, or points to a value that cannot be
+// set. For a valid pointer, Resolve returns an error when the requested service is not found
+// or cannot be resolved.
 func (r *Resolver) Resolve(target any) error {
 	// Validate the target is not nil.
 	pointerType := reflect.TypeOf(target)

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -50,3 +50,52 @@ func TestResolverService(t *testing.T) {
 	// Assert started flag is set.
 	equal(t, started.Load(), true)
 }
+
+// TestResolverResolvePanics verifies that Resolver.Resolve rejects targets that
+// are not valid non-nil writable pointers with a stable, gontainer-prefixed
+// panic instead of returning an error or leaking a reflect panic.
+func TestResolverResolvePanics(t *testing.T) {
+	resolver := &Resolver{registry: &registry{}}
+
+	// A typed nil pointer exercises the nil pointer rejection path.
+	var nilIntPtr *int
+
+	tests := []struct {
+		name string
+		call func()
+		want string
+	}{
+		{
+			name: "UntypedNil",
+			call: func() { _ = resolver.Resolve(nil) },
+			want: "expected a non-nil pointer, got nil",
+		},
+		{
+			name: "NonPointerValue",
+			call: func() { _ = resolver.Resolve(42) },
+			want: "expected a non-nil pointer, got int",
+		},
+		{
+			name: "TypedNilPointer",
+			call: func() { _ = resolver.Resolve(nilIntPtr) },
+			want: "expected a non-nil pointer",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertPanics(t, tt.want, tt.call)
+		})
+	}
+}
+
+// TestResolverResolveValidReturnsError verifies that a valid pointer never
+// panics: an unregistered type is surfaced as an error for well-formed input.
+func TestResolverResolveValidReturnsError(t *testing.T) {
+	resolver := &Resolver{registry: &registry{}}
+
+	// A valid pointer to an unregistered type must return an error.
+	var dep *testService1
+	err := resolver.Resolve(&dep)
+	equal(t, err != nil, true)
+	equal(t, dep, (*testService1)(nil))
+}


### PR DESCRIPTION
Panic on public API misuse, keep runtime failures as errors

Validate user-provided functions and pointers eagerly at the public API
border and panic on programmer errors, while genuine runtime failures are
still returned as an error.

- NewFactory/NewEntrypoint: panic on nil, non-function, typed-nil, or
  unsupported signature (validation moved from register() to construction).
- Invoker.Invoke: panic on nil, non-function, or typed-nil argument.
- Resolver.Resolve: panic on non-pointer, nil, or non-writable target.
- Add shared "gontainer:" panic prefix; document behavior and add tests.