### PR TITLE
API to tests factories as isolated from container components.

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,90 @@ for _, f := range []*gontainer.Factory{configFactory, dbFactory} {
 _ = gontainer.Run(configFactory, dbFactory, entrypoint)
 ```
 
+### Testing Factories
+
+A factory is an ordinary function, so it can be unit-tested directly - without
+starting a container. Build its `Optional[T]` and `Multiple[T]` parameters by
+hand with `NewOptional` and `NewMultiple`, then call the function and assert on
+the result:
+
+```go
+// newAPI is the function normally passed to gontainer.NewFactory.
+func newAPI(
+    metrics gontainer.Optional[*MetricsService],
+    plugins gontainer.Multiple[Plugin],
+) *API {
+    api := &API{plugins: plugins}
+    if m := metrics.Get(); m != nil {
+        api.metrics = m
+    }
+    return api
+}
+
+func TestNewAPI(t *testing.T) {
+    // A present optional (even a nil value is present) plus an ordered collection.
+    api := newAPI(
+        gontainer.NewOptional(&MetricsService{}),
+        gontainer.NewMultiple(pluginA, pluginB),
+    )
+    if api.metrics == nil || len(api.plugins) != 2 {
+        t.Fatal("expected metrics and both plugins to be wired")
+    }
+
+    // An absent optional is the zero value; no arguments make an empty collection.
+    api = newAPI(
+        gontainer.Optional[*MetricsService]{},
+        gontainer.NewMultiple[Plugin](),
+    )
+    if api.metrics != nil || len(api.plugins) != 0 {
+        t.Fatal("expected no metrics and no plugins")
+    }
+}
+```
+
+- `NewOptional(v)` always creates a present value (`Ok() == true`), even when
+  `v` is `nil`; an absent dependency is the natural zero value
+  `gontainer.Optional[T]{}`.
+- `NewMultiple(vs...)` creates a collection from `vs`, preserving their order,
+  while `NewMultiple[T]()` creates a valid empty collection.
+
+> **Note:** this approach does not work for factories that depend on the
+> built-in `*gontainer.Resolver` or `*gontainer.Invoker` services. Both are
+> provided by the container and hold an unexported reference to its registry,
+> so a working instance exists only inside a running container and cannot be
+> constructed by hand. A factory whose signature requires either of them has to
+> be tested through a container rather than in isolation.
+
+To keep such a factory testable, depend on a **local interface** that covers
+only the methods you actually call, instead of on the concrete type. The
+container still injects its built-in `*gontainer.Resolver` / `*gontainer.Invoker`
+(they satisfy the interface structurally), while a unit test can pass a fake:
+
+```go
+// resolver is the narrow slice of *gontainer.Resolver the factory relies on.
+type resolver interface {
+    Resolve(varPtr any) error
+}
+
+// newHandler is the function normally passed to gontainer.NewFactory.
+func newHandler(r resolver) *Handler {
+    var dep *Dependency
+    _ = r.Resolve(&dep)
+    return &Handler{dep: dep}
+}
+
+func TestNewHandler(t *testing.T) {
+    // fakeResolver stands in for the container-provided resolver.
+    handler := newHandler(fakeResolver{dep: &Dependency{}})
+    if handler.dep == nil {
+        t.Fatal("expected the dependency to be resolved")
+    }
+}
+```
+
+The same pattern applies to `*gontainer.Invoker` through a local
+`Invoke(function any) ([]any, error)` interface.
+
 ## API Reference
 
 ### Module Functions
@@ -461,6 +545,11 @@ func(logger gontainer.Optional[*Logger]) *Service
 // Range over the slice to access each registered service.
 func(providers gontainer.Multiple[AuthProvider]) *Router
 ```
+
+To build `Optional[T]` and `Multiple[T]` values by hand - for example, to
+unit-test a factory function without a container - use the `NewOptional` and
+`NewMultiple` constructors. See
+[Testing Factories](#testing-factories).
 
 ## Error Handling
 

--- a/multiple.go
+++ b/multiple.go
@@ -17,7 +17,10 @@
 
 package gontainer
 
-import "reflect"
+import (
+	"reflect"
+	"slices"
+)
 
 // Multiple defines a dependency on zero or more services of the same type.
 //
@@ -66,4 +69,18 @@ func isMultipleType(typ reflect.Type) (reflect.Type, bool) {
 // newMultipleValue packs multiple values to the slice.
 func newMultipleValue(typ reflect.Type, values []reflect.Value) reflect.Value {
 	return reflect.Append(reflect.Zero(typ), values...)
+}
+
+// NewMultiple creates a Multiple collection from the given values, preserving
+// their order. Calling it without arguments creates a valid empty collection.
+//
+// It is primarily meant for testing factory functions in isolation: a factory
+// that accepts a Multiple[T] parameter can be called directly with a value
+// built here, without standing up a container.
+//
+// The returned collection owns its backing storage: it holds a copy of the
+// provided values and never aliases a slice expanded at the call site with the
+// "values..." syntax, mirroring how the container builds Multiple internally.
+func NewMultiple[T any](values ...T) Multiple[T] {
+	return slices.Clone(values)
 }

--- a/multiple_test.go
+++ b/multiple_test.go
@@ -91,3 +91,67 @@ func TestNewMultipleValue(t *testing.T) {
 	value = newMultipleValue(reflect.TypeOf(box), data)
 	equal(t, value.Interface().(Multiple[string]), Multiple[string]{"result1", "result2"})
 }
+
+// mulService is a sample service used by the constructor tests.
+type mulService struct{ id int }
+
+// TestNewMultipleEmpty tests that calling NewMultiple without arguments creates
+// a valid empty collection.
+func TestNewMultipleEmpty(t *testing.T) {
+	empty := NewMultiple[*mulService]()
+	equal(t, len(empty), 0)
+}
+
+// TestNewMultipleSingle tests that NewMultiple creates a collection holding a
+// single provided value.
+func TestNewMultipleSingle(t *testing.T) {
+	serviceA := &mulService{id: 1}
+	multiple := NewMultiple(serviceA)
+	equal(t, multiple, Multiple[*mulService]{serviceA})
+}
+
+// TestNewMultipleValues tests that NewMultiple creates a collection holding all
+// provided values.
+func TestNewMultipleValues(t *testing.T) {
+	serviceA := &mulService{id: 1}
+	serviceB := &mulService{id: 2}
+	multiple := NewMultiple(serviceA, serviceB)
+	equal(t, multiple, Multiple[*mulService]{serviceA, serviceB})
+}
+
+// TestNewMultipleOrder tests that NewMultiple preserves the order of the values.
+func TestNewMultipleOrder(t *testing.T) {
+	multiple := NewMultiple(3, 1, 2)
+	equal(t, multiple, Multiple[int]{3, 1, 2})
+}
+
+// TestNewMultipleCopiesInput tests that NewMultiple copies its input and does
+// not alias a slice expanded at the call site.
+func TestNewMultipleCopiesInput(t *testing.T) {
+	source := []int{1, 2, 3}
+	multiple := NewMultiple(source...)
+
+	// Mutating the source must not affect the constructed collection.
+	source[0] = 99
+	equal(t, multiple, Multiple[int]{1, 2, 3})
+}
+
+// TestNewMultipleFactoryCall tests that a Multiple built by NewMultiple is
+// usable when a factory function is called directly.
+func TestNewMultipleFactoryCall(t *testing.T) {
+	// factory consumes a multiple dependency the same way a container would.
+	factory := func(deps Multiple[*mulService]) []int {
+		ids := make([]int, 0, len(deps))
+		for _, dep := range deps {
+			ids = append(ids, dep.id)
+		}
+		return ids
+	}
+
+	serviceA := &mulService{id: 1}
+	serviceB := &mulService{id: 2}
+	equal(t, factory(NewMultiple(serviceA, serviceB)), []int{1, 2})
+
+	// An empty collection yields no ids.
+	equal(t, factory(NewMultiple[*mulService]()), []int{})
+}

--- a/optional.go
+++ b/optional.go
@@ -100,3 +100,23 @@ func newOptionalValue(typ reflect.Type, value reflect.Value) reflect.Value {
 func newOptionalZero(typ reflect.Type) reflect.Value {
 	return reflect.New(typ).Elem()
 }
+
+// NewOptional creates a present Optional that carries the given value.
+//
+// It is primarily meant for testing factory functions in isolation: a factory
+// that accepts an Optional[T] parameter can be called directly with a value
+// built here, without standing up a container.
+//
+// The constructor always creates a present value: Ok reports true even when
+// value is the zero value of its type or a nil pointer, map, slice, channel,
+// function or interface. A present value may therefore be nil, and a nil value
+// passed here represents a present nil rather than an absent value.
+//
+// The absence of a value is represented by the zero value of Optional[T], for
+// which Ok reports false:
+//
+//	var absent Optional[*Service]         // absent, Ok() == false
+//	present := NewOptional[*Service](nil) // present nil, Ok() == true
+func NewOptional[T any](value T) Optional[T] {
+	return Optional[T]{value: value, ok: true}
+}

--- a/optional_test.go
+++ b/optional_test.go
@@ -159,3 +159,62 @@ func TestOptionalOkProvided(t *testing.T) {
 		t.Errorf("expected Get() to return %q, got %q", "hello", opt.Get())
 	}
 }
+
+// optService is a sample service used by the constructor tests.
+type optService struct{ id int }
+
+// TestOptionalZeroValueAbsent tests that the natural zero value of Optional[T]
+// represents an absent value.
+func TestOptionalZeroValueAbsent(t *testing.T) {
+	var optional Optional[*optService]
+	equal(t, optional.Ok(), false)
+	equal(t, optional.Get(), (*optService)(nil))
+}
+
+// TestNewOptional tests that NewOptional creates a present value carrying an
+// ordinary value.
+func TestNewOptional(t *testing.T) {
+	present := NewOptional(42)
+	equal(t, present.Ok(), true)
+	equal(t, present.Get(), 42)
+}
+
+// TestNewOptionalZeroValue tests that NewOptional creates a present value even
+// when the wrapped value is the zero value of a value type.
+func TestNewOptionalZeroValue(t *testing.T) {
+	presentZero := NewOptional(0)
+	equal(t, presentZero.Ok(), true)
+	equal(t, presentZero.Get(), 0)
+}
+
+// TestNewOptionalNil tests that NewOptional[*T](nil) creates a present value
+// that carries nil, rather than an absent value.
+func TestNewOptionalNil(t *testing.T) {
+	presentNil := NewOptional[*optService](nil)
+	equal(t, presentNil.Ok(), true)
+	equal(t, presentNil.Get(), (*optService)(nil))
+}
+
+// TestNewOptionalFactoryCall tests that an Optional built by NewOptional is
+// usable when a factory function is called directly.
+func TestNewOptionalFactoryCall(t *testing.T) {
+	// factory consumes an optional dependency the same way a container would.
+	factory := func(dep Optional[*optService]) (bool, *optService) {
+		return dep.Ok(), dep.Get()
+	}
+
+	svc := &optService{id: 7}
+	ok, got := factory(NewOptional(svc))
+	equal(t, ok, true)
+	equal(t, got, svc)
+
+	// A present nil dependency is still reported as present.
+	ok, got = factory(NewOptional[*optService](nil))
+	equal(t, ok, true)
+	equal(t, got, (*optService)(nil))
+
+	// A zero-value Optional is reported as absent.
+	ok, got = factory(Optional[*optService]{})
+	equal(t, ok, false)
+	equal(t, got, (*optService)(nil))
+}


### PR DESCRIPTION
Add NewOptional and NewMultiple constructors so factory functions can be unit-tested without a container. Includes tests and README docs.